### PR TITLE
🚧 Implement new server commands from Redis 6 🚧

### DIFF
--- a/command.ts
+++ b/command.ts
@@ -396,16 +396,16 @@ export type RedisCommands = {
   // Cluster
   // cluster //
   // Server
-  acl_cat(): Promise<Status>;
-  acl_deluser(): Promise<Status>;
-  acl_genpass(): Promise<Status>;
-  acl_getuser(): Promise<Status>;
-  acl_help(): Promise<Status>;
-  acl_list(): Promise<Status>;
+  // acl_cat(): Promise<Status>;
+  // acl_deluser(): Promise<Status>;
+  // acl_genpass(): Promise<Status>;
+  acl_getuser(parameter: string): Promise<BulkString[]>;
+  acl_help(): Promise<BulkString[]>;
+  acl_list(): Promise<BulkString[]>;
   acl_load(): Promise<Status>;
-  acl_log(): Promise<Status>;
+  // acl_log(): Promise<Status>;
   acl_save(): Promise<Status>;
-  acl_setuser(): Promise<Status>;
+  // acl_setuser(): Promise<Status>;
   acl_users(): Promise<Status>;
   acl_whoami(): Promise<Status>;
   bgrewriteaof(): Promise<Status>;

--- a/command.ts
+++ b/command.ts
@@ -450,6 +450,9 @@ export type RedisCommands = {
       samples?: number;
     },
   ): Promise<Integer>;
+  module_list(): Promise<BulkString[]>;
+  module_load(path: string, args: string): Promise<Status>;
+  module_unload(name: string): Promise<Status>;
   monitor(): void;
   role(): Promise<
     | ["master", Integer, BulkString[][]]

--- a/command.ts
+++ b/command.ts
@@ -11,6 +11,7 @@ export type ConditionalArray = Raw[];
 export type RedisCommands = {
   // Connection
   auth(password: string): Promise<Status>;
+  auth(username: string, password: string): Promise<Status>;
   echo(message: string): Promise<BulkString>;
   ping(): Promise<Status>;
   ping(message: string): Promise<BulkString>;
@@ -396,7 +397,6 @@ export type RedisCommands = {
   // Cluster
   // cluster //
   // Server
-  acl_auth(username: string, passwd: string): Promise<Status>;
   acl_cat(parameter?: string): Promise<BulkString[]>;
   acl_deluser(parameter: string): Promise<Integer>;
   acl_genpass(parameter?: number): Promise<Status>;

--- a/command.ts
+++ b/command.ts
@@ -396,17 +396,18 @@ export type RedisCommands = {
   // Cluster
   // cluster //
   // Server
+  acl_auth(username: string, passwd: string): Promise<Status>;
   acl_cat(parameter?: string): Promise<BulkString[]>;
   acl_deluser(parameter: string): Promise<Integer>;
-  // acl_genpass(): Promise<Status>;
+  acl_genpass(parameter?: number): Promise<Status>;
   acl_getuser(parameter: string): Promise<BulkString[]>;
   acl_help(): Promise<BulkString[]>;
   acl_list(): Promise<BulkString[]>;
   acl_load(): Promise<Status>;
-  // acl_log(): Promise<Status>;
+  acl_log(parameter: string | number): Promise<Status | BulkString[]>;
   acl_save(): Promise<Status>;
-  // acl_setuser(): Promise<Status>;
-  acl_users(): Promise<Status>;
+  acl_setuser(username: string, rule: string): Promise<Status>;
+  acl_users(): Promise<BulkString[]>;
   acl_whoami(): Promise<Status>;
   bgrewriteaof(): Promise<Status>;
   bgsave(): Promise<Status>;

--- a/command.ts
+++ b/command.ts
@@ -396,7 +396,7 @@ export type RedisCommands = {
   // Cluster
   // cluster //
   // Server
-  // acl_cat(): Promise<Status>;
+  acl_cat(parameter?: string): Promise<BulkString[]>;
   // acl_deluser(): Promise<Status>;
   // acl_genpass(): Promise<Status>;
   acl_getuser(parameter: string): Promise<BulkString[]>;

--- a/command.ts
+++ b/command.ts
@@ -396,6 +396,18 @@ export type RedisCommands = {
   // Cluster
   // cluster //
   // Server
+  acl_cat(): Promise<Status>;
+  acl_deluser(): Promise<Status>;
+  acl_genpass(): Promise<Status>;
+  acl_getuser(): Promise<Status>;
+  acl_help(): Promise<Status>;
+  acl_list(): Promise<Status>;
+  acl_load(): Promise<Status>;
+  acl_log(): Promise<Status>;
+  acl_save(): Promise<Status>;
+  acl_setuser(): Promise<Status>;
+  acl_users(): Promise<Status>;
+  acl_whoami(): Promise<Status>;
   bgrewriteaof(): Promise<Status>;
   bgsave(): Promise<Status>;
   // client //

--- a/command.ts
+++ b/command.ts
@@ -397,7 +397,7 @@ export type RedisCommands = {
   // cluster //
   // Server
   acl_cat(parameter?: string): Promise<BulkString[]>;
-  // acl_deluser(): Promise<Status>;
+  acl_deluser(parameter: string): Promise<Integer>;
   // acl_genpass(): Promise<Status>;
   acl_getuser(parameter: string): Promise<BulkString[]>;
   acl_help(): Promise<BulkString[]>;

--- a/redis.ts
+++ b/redis.ts
@@ -97,6 +97,10 @@ class RedisImpl implements RedisCommands {
     }
   }
 
+  acl_deluser(username: string) {
+    return this.execIntegerReply("ACL", "DELUSER", username);
+  }
+
   acl_getuser(username: string) {
     return this.execArrayReply<BulkString>("ACL", "GETUSER", username);
   }

--- a/redis.ts
+++ b/redis.ts
@@ -89,10 +89,6 @@ class RedisImpl implements RedisCommands {
     return reply as Status | BulkNil;
   }
 
-  acl_auth(username: string, passwd: string) {
-    return this.execStatusReply("AUTH", username, passwd);
-  }
-
   acl_cat(categoryname?: string) {
     if (categoryname) {
       return this.execArrayReply<BulkString>("ACL", "CAT", categoryname);

--- a/redis.ts
+++ b/redis.ts
@@ -728,6 +728,18 @@ class RedisImpl implements RedisCommands {
     return this.execStatusReply("MIGRATE", ...args);
   }
 
+  module_list() {
+    return this.execArrayReply<BulkString>("MODULE", "LIST");
+  }
+
+  module_load(path: string, args: string) {
+    return this.execStatusReply("MODULE", "LOAD", path, args);
+  }
+
+  module_unload(name: string) {
+    return this.execStatusReply("MODULE", "UNLOAD", name);
+  }
+
   monitor() {
     throw new Error("not supported yet");
   }

--- a/redis.ts
+++ b/redis.ts
@@ -133,10 +133,7 @@ class RedisImpl implements RedisCommands {
     if (param === "RESET" || param === "reset") {
       return this.execStatusReply("ACL", "LOG", "RESET");
     }
-    // if (typeof param == "number") {
     return this.execArrayReply<BulkString>("ACL", "LOG", param);
-    // }
-    // return this.execStatusReply("ACL", "LOAD");
   }
 
   acl_save() {

--- a/redis.ts
+++ b/redis.ts
@@ -89,6 +89,14 @@ class RedisImpl implements RedisCommands {
     return reply as Status | BulkNil;
   }
 
+  acl_cat(categoryname?: string) {
+    if (categoryname) {
+      return this.execArrayReply<BulkString>("ACL", "CAT", categoryname);
+    } else {
+      return this.execArrayReply<BulkString>("ACL", "CAT");
+    }
+  }
+
   acl_getuser(username: string) {
     return this.execArrayReply<BulkString>("ACL", "GETUSER", username);
   }

--- a/redis.ts
+++ b/redis.ts
@@ -89,6 +89,10 @@ class RedisImpl implements RedisCommands {
     return reply as Status | BulkNil;
   }
 
+  acl_auth(username: string, passwd: string) {
+    return this.execStatusReply("AUTH", username, passwd);
+  }
+
   acl_cat(categoryname?: string) {
     if (categoryname) {
       return this.execArrayReply<BulkString>("ACL", "CAT", categoryname);
@@ -99,6 +103,14 @@ class RedisImpl implements RedisCommands {
 
   acl_deluser(username: string) {
     return this.execIntegerReply("ACL", "DELUSER", username);
+  }
+
+  acl_genpass(bits?: Integer) {
+    if (bits) {
+      return this.execStatusReply("ACL", "GENPASS", bits);
+    } else {
+      return this.execStatusReply("ACL", "GENPASS");
+    }
   }
 
   acl_getuser(username: string) {
@@ -117,12 +129,26 @@ class RedisImpl implements RedisCommands {
     return this.execStatusReply("ACL", "LOAD");
   }
 
+  acl_log(param: string|number) {
+    if (param === "RESET" || param === "reset") {
+      return this.execStatusReply("ACL", "LOG", "RESET");
+    }
+    // if (typeof param == "number") {
+    return this.execArrayReply<BulkString>("ACL", "LOG", param);
+    // }
+    // return this.execStatusReply("ACL", "LOAD");
+  }
+
   acl_save() {
     return this.execStatusReply("ACL", "SAVE");
   }
 
+  acl_setuser(username: string, rule: string) {
+    return this.execStatusReply("ACL", "SETUSER", username, rule);
+  }
+
   acl_users() {
-    return this.execStatusReply("ACL", "USERS");
+    return this.execArrayReply<BulkString>("ACL", "USERS");
   }
 
   acl_whoami() {

--- a/redis.ts
+++ b/redis.ts
@@ -156,8 +156,11 @@ class RedisImpl implements RedisCommands {
     return this.execIntegerReply("APPEND", key, value);
   }
 
-  auth(password: string) {
-    return this.execStatusReply("AUTH", password);
+  auth(param1: string, param2?: string) {
+    if (typeof param2 === "string") {
+      return this.execStatusReply("AUTH", param1, param2);
+    }
+    return this.execStatusReply("AUTH", param1);
   }
 
   bgrewriteaof() {

--- a/redis.ts
+++ b/redis.ts
@@ -89,6 +89,34 @@ class RedisImpl implements RedisCommands {
     return reply as Status | BulkNil;
   }
 
+  acl_getuser(username: string) {
+    return this.execArrayReply<BulkString>("ACL", "GETUSER", username);
+  }
+
+  acl_help() {
+    return this.execArrayReply<BulkString>("ACL", "HELP");
+  }
+
+  acl_list() {
+    return this.execArrayReply<BulkString>("ACL", "LIST");
+  }
+
+  acl_load() {
+    return this.execStatusReply("ACL", "LOAD");
+  }
+
+  acl_save() {
+    return this.execStatusReply("ACL", "SAVE");
+  }
+
+  acl_users() {
+    return this.execStatusReply("ACL", "USERS");
+  }
+
+  acl_whoami() {
+    return this.execStatusReply("ACL", "WHOAMI");
+  }
+
   append(key: string, value: string | number) {
     return this.execIntegerReply("APPEND", key, value);
   }

--- a/redis_test.ts
+++ b/redis_test.ts
@@ -8,3 +8,4 @@ import "./tests/set_test.ts";
 import "./tests/sorted_set_test.ts";
 import "./tests/string_test.ts";
 import "./tests/key_test.ts";
+import "./tests/acl_cmd_test.ts";

--- a/tests/acl_cmd_test.ts
+++ b/tests/acl_cmd_test.ts
@@ -80,3 +80,7 @@ test("cat", async () => {
     "slowlog"
   ]);
 });
+
+test("deluser", async () => {
+  assertEquals(await client.acl_deluser("balhblahblah"), 0);
+});

--- a/tests/acl_cmd_test.ts
+++ b/tests/acl_cmd_test.ts
@@ -1,0 +1,21 @@
+import { makeTest } from "./test_util.ts";
+import {
+  assertEquals,
+} from "../vendor/https/deno.land/std/testing/asserts.ts";
+
+const { test, client } = await makeTest("acl_cmd");
+
+test("whoami", async () => {
+  assertEquals(await client.acl_whoami(), "default");
+});
+
+test("list", async () => {
+  assertEquals(await client.acl_list(), ["user default on nopass ~* +@all"]);
+});
+
+test("getuser", async () => {
+  assertEquals(await client.acl_getuser("default"),
+  [ "flags",[ "on", "allkeys", "allcommands", "nopass" ],
+    "passwords", [], "commands", "+@all", "keys", [ "*" ]
+  ]);
+});

--- a/tests/acl_cmd_test.ts
+++ b/tests/acl_cmd_test.ts
@@ -19,3 +19,64 @@ test("getuser", async () => {
     "passwords", [], "commands", "+@all", "keys", [ "*" ]
   ]);
 });
+
+test("cat", async () => {
+  assertEquals(await client.acl_cat(),
+  [
+    "keyspace",
+    "read",
+    "write",
+    "set",
+    "sortedset",
+    "list",
+    "hash",
+    "string",
+    "bitmap",
+    "hyperloglog",
+    "geo",
+    "stream",
+    "pubsub",
+    "admin",
+    "fast",
+    "slow",
+    "blocking",
+    "dangerous",
+    "connection",
+    "transaction",
+    "scripting"
+  ]);
+  assertEquals(await client.acl_cat("dangerous"),
+  [
+    "lastsave",
+    "shutdown",
+    "module",
+    "monitor",
+    "role",
+    "client",
+    "replconf",
+    "config",
+    "pfselftest",
+    "save",
+    "replicaof",
+    "restore-asking",
+    "restore",
+    "latency",
+    "swapdb",
+    "slaveof",
+    "bgsave",
+    "debug",
+    "bgrewriteaof",
+    "sync",
+    "flushdb",
+    "keys",
+    "psync",
+    "pfdebug",
+    "flushall",
+    "cluster",
+    "info",
+    "migrate",
+    "acl",
+    "sort",
+    "slowlog"
+  ]);
+});

--- a/tests/acl_cmd_test.ts
+++ b/tests/acl_cmd_test.ts
@@ -21,7 +21,7 @@ test("getuser", async () => {
 });
 
 test("cat", async () => {
-  assertEquals(await client.acl_cat(),
+  assertEquals((await client.acl_cat()).sort(),
   [
     "keyspace",
     "read",
@@ -44,8 +44,8 @@ test("cat", async () => {
     "connection",
     "transaction",
     "scripting"
-  ]);
-  assertEquals(await client.acl_cat("dangerous"),
+  ].sort());
+  assertEquals((await client.acl_cat("dangerous")).sort(),
   [
     "lastsave",
     "shutdown",
@@ -78,9 +78,39 @@ test("cat", async () => {
     "acl",
     "sort",
     "slowlog"
-  ]);
+  ].sort());
+});
+
+test("users", async () => {
+  assertEquals(await client.acl_users(), ["default"])
+});
+
+test("acl_setuser", async () => {
+  assertEquals(await client.acl_setuser("alan", "+get"), "OK")
+  assertEquals(await client.acl_deluser("alan"), 1);
 });
 
 test("deluser", async () => {
-  assertEquals(await client.acl_deluser("balhblahblah"), 0);
+  assertEquals(await client.acl_deluser("alan"), 0);
+});
+
+test("genpass", async () => {
+  assertEquals((await client.acl_genpass()).length, 64);
+  let testlen = 32
+  assertEquals((await client.acl_genpass(testlen)).length, testlen / 4);
+});
+
+test("aclauth", async () => {
+  assertEquals(await client.acl_auth("default", ""), "OK")
+});
+
+test("log", async () => {
+  let username = "balh"
+  try {
+    await client.acl_auth(username, username)
+  } catch (error) {
+    // skip invalid username-password pair error
+  }
+  assertEquals((await client.acl_log(1))[0][9], username);
+  assertEquals((await client.acl_log("RESET")), "OK");
 });

--- a/tests/acl_cmd_test.ts
+++ b/tests/acl_cmd_test.ts
@@ -114,3 +114,7 @@ test("log", async () => {
   assertEquals((await client.acl_log(1))[0][9], username);
   assertEquals((await client.acl_log("RESET")), "OK");
 });
+
+test("module_list", async () => {
+  assertEquals(await client.module_list(), []);
+});

--- a/tests/acl_cmd_test.ts
+++ b/tests/acl_cmd_test.ts
@@ -101,17 +101,17 @@ test("genpass", async () => {
 });
 
 test("aclauth", async () => {
-  assertEquals(await client.acl_auth("default", ""), "OK")
+  assertEquals(await client.auth("default", ""), "OK")
 });
 
 test("log", async () => {
-  let username = "balh"
+  let randString = "balh"
   try {
-    await client.acl_auth(username, username)
+    await client.auth(randString, randString)
   } catch (error) {
     // skip invalid username-password pair error
   }
-  assertEquals((await client.acl_log(1))[0][9], username);
+  assertEquals((await client.acl_log(1))[0][9], randString);
   assertEquals((await client.acl_log("RESET")), "OK");
 });
 


### PR DESCRIPTION
### Work in progress
Use @Terkwood's #86 as request template.

Adds support for Redis Server commands.
This change set will resolve #35 . 🚢

### Commands to implement

- [x] ACL CAT
- [x] ACL DELUSER
- [x] ACL GENPASS
- [x] ACL GETUSER
- [x] ACL HELP
- [x] ACL LIST
- [x] ACL LOAD
- [x] ACL LOG
- [x] ACL SAVE
- [x] ACL SETUSER
- [x] ACL USERS
- [x] ACL WHOAMI
- [x] MODULE LIST
- [x] MODULE LOAD
- [x] MODULE UNLOAD

### Docs and sanity checks

Author will run each command and verify that argument names match the canonical names exposed by Redis. Minimal command form should be included in EACH doc string. Author will check each TS return type to make sure it matches server return type (Ideally these are encoded in the test). This isn't ideal since only exports trigger deno doc, but we want to have these methods documented nonetheless.

- [x] ACL CAT
- [x] ACL DELUSER
- [x] ACL GENPASS
- [x] ACL GETUSER
- [x] ACL HELP
- [x] ACL LIST
- [x] ACL LOAD
- [x] ACL LOG
- [x] ACL SAVE
- [x] ACL SETUSER
- [x] ACL USERS
- [x] ACL WHOAMI
- [x] MODULE LIST

### Additional requirements

- [x]  Create test suit