### PR TITLE
Implement retriable connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,28 @@ const sub = await redis.subscribe("channel");
 
 ## Advanced Usage
 
+### Retriable connection
+
+By default, a client's connection will throw an error if the server dies or the network becomes unavailable.
+A connection can be made "retriable" by setting the value `maxRetryCount` when connecting a new client.
+
+```ts
+const redis = await connect({ ...options, maxRetryCount: 10 });
+
+// The client will try to connect to the server 10 times if the server dies or the network becomes unavailable.
+```
+
+The property is set automatically to `10` when creating a subscriber client.
+After a reconnection succeeds, the client will subscribe again to all the channels and patterns.
+
+```ts
+const redis = await connect(options);
+const subscriberClient = await redis.subscribe("channel");
+
+// The client's connection will now be forced to try to connect to the server 10 times if the server dies or the network
+//   becomes unavailable.
+```
+
 ### Execute raw commands
 
 `redis.executor` is raw level [redis protocol](https://redis.io/topics/protocol) executor.

--- a/command.ts
+++ b/command.ts
@@ -535,5 +535,6 @@ export type RedisCommands = {
   ): Promise<[BulkString, BulkString[]]>;
 
   readonly isClosed: boolean;
+  readonly isConnected: boolean;
   close(): void;
 };

--- a/connection.ts
+++ b/connection.ts
@@ -1,0 +1,197 @@
+import { BufReader, BufWriter } from "./vendor/https/deno.land/std/io/bufio.ts";
+import {
+  CommandExecutor,
+  CommandFunc,
+  RedisRawReply,
+  muxExecutor,
+  sendCommand,
+} from "./io.ts";
+
+// type Reader = Deno.Reader;
+// type Writer = Deno.Writer;
+type Closer = Deno.Closer;
+
+export type RedisConnectOptions = {
+  hostname?: string;
+  port?: number | string;
+  tls?: boolean;
+  db?: number;
+  password?: string;
+  name?: string;
+  maxRetryCount?: number;
+};
+
+export class RedisConnection {
+  name: string | null = null;
+  closer: Closer | null = null;
+  reader: BufReader | null = null;
+  writer: BufWriter | null = null;
+
+  executor: CommandExecutor | null = null;
+
+  get exec(): CommandFunc<RedisRawReply> {
+    return this.executor!.exec;
+  }
+
+  private _isConnected: boolean = false;
+
+  get isConnected(): boolean {
+    return this._isConnected;
+  }
+
+  private _isClosed: boolean = false;
+
+  get isClosed(): boolean {
+    return this._isClosed;
+  }
+
+  maxRetryCount = 0;
+  private retryCount = 0;
+
+  private connectThunkified: () => Promise<RedisConnection>;
+  private thunkifyConnect(
+    hostname: string,
+    port: string | number,
+    options: RedisConnectOptions,
+  ): () => Promise<RedisConnection> {
+    return async () => {
+      const dialOpts: Deno.ConnectOptions = {
+        hostname,
+        port: parsePortLike(port),
+      };
+      if (!Number.isSafeInteger(dialOpts.port)) {
+        throw new Error("deno-redis: opts.port is invalid");
+      }
+      const conn: Deno.Conn = options?.tls
+        ? await Deno.connectTls(dialOpts)
+        : await Deno.connect(dialOpts);
+
+      if (options.name) this.name = options.name;
+      if (options.maxRetryCount) this.maxRetryCount = options.maxRetryCount;
+
+      this.closer = conn;
+      this.reader = new BufReader(conn);
+      this.writer = new BufWriter(conn);
+      this.executor = muxExecutor(this, this.maxRetryCount > 0);
+
+      this._isClosed = false;
+      this._isConnected = true;
+
+      try {
+        if (options?.password != null) {
+          await this.authenticate(options.password);
+        }
+        if (options?.db) await this.selectDb(options.db);
+      } catch (error) {
+        this.close();
+        throw error;
+      }
+
+      return this as RedisConnection;
+    };
+  }
+
+  constructor(
+    hostname: string,
+    port: number | string,
+    private options: RedisConnectOptions,
+  ) {
+    this.connectThunkified = this.thunkifyConnect(hostname, port, options);
+  }
+
+  private authenticate(
+    password: string,
+  ): Promise<RedisRawReply> {
+    const readerAsBuffer = this.reader as BufReader;
+    const writerAsBuffer = this.writer as BufWriter;
+
+    return sendCommand(writerAsBuffer, readerAsBuffer, "AUTH", password);
+  }
+
+  private selectDb(
+    databaseIndex: number | undefined = this.options.db,
+  ): Promise<RedisRawReply> {
+    if (!databaseIndex) throw new Error("The database index is undefined.");
+
+    const readerAsBuffer = this.reader as BufReader;
+    const writerAsBuffer = this.writer as BufWriter;
+
+    return sendCommand(writerAsBuffer, readerAsBuffer, "SELECT", databaseIndex);
+  }
+
+  close() {
+    this._isClosed = true;
+    this._isConnected = false;
+    try {
+      this.closer!.close();
+    } catch (error) {
+      if (!(error instanceof Deno.errors.BadResource)) throw error;
+    }
+  }
+
+  /**
+   * Connect to Redis server
+   */
+  async connect(): Promise<RedisConnection> {
+    return this.connectThunkified();
+  }
+
+  async reconnect(): Promise<RedisConnection> {
+    const readerAsBuffer = this.reader as BufReader;
+    const writerAsBuffer = this.writer as BufWriter;
+    if (!readerAsBuffer.peek(1)) throw new Error("Client is closed.");
+
+    try {
+      await sendCommand(writerAsBuffer, readerAsBuffer, "PING");
+      this._isConnected = true;
+
+      return Promise.resolve(this);
+    } catch (error) {
+      this._isConnected = false;
+      return new Promise(
+        (resolve, reject) => {
+          const interval = setInterval(
+            async () => {
+              if (this.retryCount > this.maxRetryCount) {
+                await this.close();
+                clearInterval(interval);
+                reject(new Error("Could not reconnect"));
+              }
+
+              try {
+                await this.close();
+                await this.connect();
+
+                await sendCommand(
+                  this.writer as BufWriter,
+                  this.reader as BufReader,
+                  "PING",
+                );
+
+                this._isConnected = true;
+                this.retryCount = 0;
+                clearInterval(interval);
+                resolve(this);
+              } finally {
+                this.retryCount++;
+              }
+            },
+            1200,
+          );
+        },
+      );
+    }
+  }
+}
+
+function parsePortLike(port: string | number | undefined): number {
+  if (typeof port === "string") {
+    return parseInt(port);
+  } else if (typeof port === "number") {
+    return port;
+  } else if (port === undefined) {
+    return 6379;
+  } else {
+    throw new Error("port is invalid: typeof=" + typeof port);
+  }
+}

--- a/pubsub_test.ts
+++ b/pubsub_test.ts
@@ -1,7 +1,10 @@
 import {
-  assertEquals,
   assert,
+  assertEquals,
+  assertThrowsAsync,
 } from "./vendor/https/deno.land/std/testing/asserts.ts";
+import { delay } from "./vendor/https/deno.land/std/async/mod.ts";
+
 import { connect } from "./redis.ts";
 const { test } = Deno;
 const addr = {
@@ -39,10 +42,14 @@ test({
       message: "wayway",
     });
     await sub.close();
-    const a = await redis.get("aaa");
-    assertEquals(a, undefined);
-    pub.close();
-    redis.close();
+
+    assertEquals(sub.isClosed, true);
+    assertEquals(redis.isClosed, true);
+
+    await pub.close();
+    await assertThrowsAsync(async () => {
+      await redis.get("aaa");
+    }, Deno.errors.BadResource);
   },
 });
 
@@ -79,17 +86,112 @@ test({
 });
 
 test({
-  name:
-    "testSubscriptionShouldNotThrowBadResourceErrorWhenConnectionIsClosed (#89)",
-  async fn() {
-    const redis = await connect(addr);
-    const sub = await redis.subscribe("test");
-    const subscriptionPromise = (async () => {
-      // deno-lint-ignore no-empty
-      for await (const _ of sub.receive()) {}
-    })();
-    redis.close();
-    await subscriptionPromise;
-    assert(sub.isClosed);
+  name: "testSubscribe4 (#83)",
+
+  // sanitizeResources: false,
+  // sanitizeOps: false,
+  async fn(): Promise<void> {
+    let parallelPromiseList: Promise<number>[] = [];
+
+    const throwawayRedisServerPort = 6464;
+    let promiseList;
+    let throwawayRedisServerChildProcess = createThrowawayRedisServer(
+      throwawayRedisServerPort,
+    );
+
+    await delay(500);
+
+    const redisClient = await connect(
+      { ...addr, name: "Main", port: throwawayRedisServerPort },
+    );
+    const publisherRedisClient = await connect(
+      {
+        ...addr,
+        maxRetryCount: 10,
+        name: "Publisher",
+        port: throwawayRedisServerPort,
+      },
+    );
+    const subscriberRedisClient = await redisClient.psubscribe("ps*");
+
+    const messageIterator = subscriberRedisClient.receive();
+
+    const interval = setInterval(
+      () => {
+        parallelPromiseList.push(
+          publisherRedisClient.publish("psub", "wayway"),
+        );
+      },
+      900,
+    );
+
+    setTimeout(
+      async () => {
+        throwawayRedisServerChildProcess.close();
+      },
+      1000,
+    );
+
+    setTimeout(async () => {
+      assertEquals(
+        redisClient.isConnected,
+        false,
+        "The main client still thinks it is connected.",
+      );
+      assertEquals(
+        publisherRedisClient.isConnected,
+        false,
+        "The publisher client still thinks it is connected.",
+      );
+      assert(
+        parallelPromiseList.length < 5,
+        "Too many messages were published.",
+      );
+
+      throwawayRedisServerChildProcess = createThrowawayRedisServer(
+        throwawayRedisServerPort,
+      );
+
+      await delay(500);
+      const temporaryRedisClient = await connect(
+        { ...addr, port: throwawayRedisServerPort },
+      );
+      await temporaryRedisClient.ping();
+      temporaryRedisClient.close();
+
+      await delay(1000);
+
+      assert(redisClient.isConnected, "The main client is not connected.");
+      assert(
+        publisherRedisClient.isConnected,
+        "The publisher client is not connected.",
+      );
+    }, 2000);
+
+    promiseList = Promise.all([
+      messageIterator.next(),
+      messageIterator.next(),
+      messageIterator.next(),
+      messageIterator.next(),
+      messageIterator.next(),
+    ]);
+
+    await promiseList;
+
+    clearInterval(interval);
+
+    throwawayRedisServerChildProcess.close();
+    publisherRedisClient.close();
+    redisClient.close();
   },
 });
+
+function createThrowawayRedisServer(port: number) {
+  return Deno.run(
+    {
+      cmd: ["redis-server", "--port", port.toString()],
+      stdin: "null",
+      stdout: "null",
+    },
+  );
+}

--- a/redis.ts
+++ b/redis.ts
@@ -1,17 +1,11 @@
 type Reader = Deno.Reader;
 type Writer = Deno.Writer;
 type Closer = Deno.Closer;
-import {
-  BufReader,
-  BufWriter,
-} from "./vendor/https/deno.land/std/io/bufio.ts";
-import { psubscribe, RedisSubscription, subscribe } from "./pubsub.ts";
-import {
-  muxExecutor,
-  CommandExecutor,
-  RedisRawReply,
-} from "./io.ts";
-import { createRedisPipeline, RedisPipeline } from "./pipeline.ts";
+
+import { BufReader, BufWriter } from "./vendor/https/deno.land/std/io/bufio.ts";
+import { psubscribe, subscribe } from "./pubsub.ts";
+import { CommandExecutor, CommandFunc, RedisRawReply } from "./io.ts";
+import { createRedisPipeline } from "./pipeline.ts";
 import {
   RedisCommands,
   Status,
@@ -22,30 +16,39 @@ import {
   Raw,
   BulkNil,
 } from "./command.ts";
+import { RedisConnection } from "./connection.ts";
 
 export type Redis = RedisCommands & {
   executor: CommandExecutor;
 };
 
 class RedisImpl implements RedisCommands {
-  _isClosed = false;
   get isClosed() {
-    return this._isClosed;
+    return this.connection?.isClosed;
+  }
+
+  get isConnected() {
+    return this.connection?.isConnected;
+  }
+
+  get executor() {
+    return this.connection?.executor!;
   }
 
   constructor(
-    private closer: Closer,
-    private writer: BufWriter,
-    private reader: BufReader,
-    readonly executor: CommandExecutor,
+    private connection: RedisConnection,
   ) {
+  }
+
+  close() {
+    return this.connection?.close();
   }
 
   async execStatusReply(
     command: string,
     ...args: (string | number)[]
   ): Promise<Status> {
-    const [_, reply] = await this.executor.exec(command, ...args);
+    const [_, reply] = await this.connection?.executor!.exec(command, ...args);
     return reply as Status;
   }
 
@@ -53,7 +56,7 @@ class RedisImpl implements RedisCommands {
     command: string,
     ...args: (string | number)[]
   ): Promise<Integer> {
-    const [_, reply] = await this.executor.exec(command, ...args);
+    const [_, reply] = await this.connection!.exec(command, ...args);
     return reply as number;
   }
 
@@ -61,7 +64,7 @@ class RedisImpl implements RedisCommands {
     command: string,
     ...args: (string | number)[]
   ): Promise<T> {
-    const [_, reply] = await this.executor.exec(command, ...args);
+    const [_, reply] = await this.connection!.exec(command, ...args);
     return reply as T;
   }
 
@@ -69,7 +72,7 @@ class RedisImpl implements RedisCommands {
     command: string,
     ...args: (string | number)[]
   ): Promise<T[]> {
-    const [_, reply] = await this.executor.exec(command, ...args);
+    const [_, reply] = await this.connection!.exec(command, ...args);
     return reply as T[];
   }
 
@@ -77,7 +80,7 @@ class RedisImpl implements RedisCommands {
     command: string,
     ...args: (string | number)[]
   ): Promise<Integer | BulkNil> {
-    const [_, reply] = await this.executor.exec(command, ...args);
+    const [_, reply] = await this.connection!.exec(command, ...args);
     return reply as Integer | BulkNil;
   }
 
@@ -85,7 +88,7 @@ class RedisImpl implements RedisCommands {
     command: string,
     ...args: (string | number)[]
   ): Promise<Status | BulkNil> {
-    const [_, reply] = await this.executor.exec(command, ...args);
+    const [_, reply] = await this.connection!.exec(command, ...args);
     return reply as Status | BulkNil;
   }
 
@@ -374,7 +377,7 @@ class RedisImpl implements RedisCommands {
     } else {
       _args.push(...args);
     }
-    const [_, raw] = await this.executor.exec(cmd, ..._args);
+    const [_, raw] = await this.connection!.exec(cmd, ..._args);
     return raw;
   }
 
@@ -820,11 +823,11 @@ class RedisImpl implements RedisCommands {
   }
 
   subscribe(...channels: string[]) {
-    return subscribe(this.writer, this.reader, ...channels);
+    return subscribe(this.connection, ...channels);
   }
 
   psubscribe(...patterns: string[]) {
-    return psubscribe(this.writer, this.reader, ...patterns);
+    return psubscribe(this.connection, ...patterns);
   }
 
   pubsub_channels(pattern: string) {
@@ -854,11 +857,10 @@ class RedisImpl implements RedisCommands {
   }
 
   quit() {
-    try {
-      return this.execStatusReply("QUIT");
-    } finally {
-      this._isClosed = true;
-    }
+    return this.execStatusReply("QUIT")
+      .finally(() => {
+        this.connection?.close();
+      });
   }
 
   randomkey() {
@@ -1047,7 +1049,7 @@ class RedisImpl implements RedisCommands {
   }
 
   slowlog(subcommand: string, ...argument: string[]) {
-    return this.executor.exec("SLOWLOG", subcommand, ...argument);
+    return this.connection!.exec("SLOWLOG", subcommand, ...argument);
   }
 
   smembers(key: string) {
@@ -1519,17 +1521,11 @@ class RedisImpl implements RedisCommands {
 
   // pipeline
   tx() {
-    return createRedisPipeline(this.writer, this.reader, { tx: true });
+    return createRedisPipeline(this.connection, { tx: true });
   }
 
   pipeline() {
-    return createRedisPipeline(this.writer, this.reader);
-  }
-
-  // Stream
-
-  close() {
-    this.closer.close();
+    return createRedisPipeline(this.connection);
   }
 }
 
@@ -1539,6 +1535,8 @@ export type RedisConnectOptions = {
   tls?: boolean;
   db?: number;
   password?: string;
+  name?: string;
+  maxRetryCount?: number;
 };
 
 function parsePortLike(port: string | number | undefined): number {
@@ -1562,38 +1560,22 @@ function parsePortLike(port: string | number | undefined): number {
  */
 export async function connect({
   hostname,
-  port,
+  port = 6379,
   tls,
   db,
   password,
+  name,
+  maxRetryCount,
 }: RedisConnectOptions): Promise<Redis> {
-  const dialOpts: Deno.ConnectOptions = {
+  const connection = new RedisConnection(
     hostname,
-    port: parsePortLike(port),
-  };
-  if (!Number.isSafeInteger(dialOpts.port)) {
-    throw new Error("deno-redis: opts.port is invalid");
-  }
-  const conn: Deno.Conn = tls
-    ? await Deno.connectTls(dialOpts)
-    : await Deno.connect(dialOpts);
+    port,
+    { tls, db, maxRetryCount, name, password },
+  );
 
-  const bufr = new BufReader(conn);
-  const bufw = new BufWriter(conn);
-  const exec = muxExecutor(bufr, bufw);
-  const client = await create(conn, conn, conn, exec);
-  if (password != null) {
-    try {
-      await client.auth(password);
-    } catch (err) {
-      client.close();
-      throw err;
-    }
-  }
-  if (db) {
-    await client.select(db);
-  }
-  return client;
+  await connection.connect();
+
+  return new RedisImpl(connection);
 }
 
 export function create(
@@ -1602,10 +1584,19 @@ export function create(
   reader: Reader,
   executor: CommandExecutor,
 ): Redis {
-  return new RedisImpl(
+  return new RedisImpl({
     closer,
-    new BufWriter(writer),
-    new BufReader(reader),
     executor,
-  );
+    reader,
+    writer,
+    get exec(): CommandFunc<RedisRawReply> {
+      return executor.exec;
+    },
+    get isConnected(): boolean {
+      return true;
+    },
+    get isClosed(): boolean {
+      return false;
+    },
+  } as RedisConnection);
 }

--- a/tests/connection_test.ts
+++ b/tests/connection_test.ts
@@ -17,7 +17,6 @@ test("quit", async () => {
   const redis = await connect({ hostname: "127.0.0.1", port: 6379 });
   assertEquals(await redis.quit(), "OK");
   assertEquals(redis.isClosed, true);
-  redis.close();
 });
 test("select", async () => {
   assertEquals(await client.select(1), "OK");


### PR DESCRIPTION
Add a test for an issue that was reported where the process exits if the connection to the Redis server is lost while being subscribed to a topic.

To run this test, you will need to specifically allow to run (execute) commands and enable the unstable API -- `deno test --allow-net --allow-run --unstable`

Reference: https://github.com/keroxp/deno-redis/issues/83