### PR TITLE
Fix bad reference to property `channels`

### DIFF
--- a/pubsub.ts
+++ b/pubsub.ts
@@ -34,7 +34,7 @@ class RedisSubscriptionImpl implements RedisSubscription {
   async psubscribe(...patterns: string[]) {
     await sendCommand(this.writer, this.reader, "PSUBSCRIBE", ...patterns);
     for (const pat of patterns) {
-      this.channels[pat] = true;
+      this.patterns[pat] = true;
     }
   }
 


### PR DESCRIPTION
I think this is a mistake; `psubscribe` refers to `this.channels` and `punsubscribe` refers to `this.patterns`...