### PR TITLE
fix(#104): re-enable testSubscribe4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
         - 6379:6379
     env:
       USE_DOCKER: "1"
+      DOCKER_BIN: "/usr/bin/docker"
     steps:
       - uses: actions/checkout@v1
       - name: Install Deno

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
         image: redis
         ports:
         - 6379:6379
+    env:
+      USE_DOCKER: "1"
     steps:
       - uses: actions/checkout@v1
       - name: Install Deno

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ jobs:
       - uses: denolib/setup-deno@master
         with:
           deno-version: ${{ env.DENO_VERSION }}
+      - name: Echo docker path
+        run: |
+          echo "$(which docker)"
       - name: Check mod.ts
         run: |
           deno run --allow-read --allow-write tools/make_mod.ts

--- a/tests/test_util.ts
+++ b/tests/test_util.ts
@@ -65,7 +65,7 @@ export async function startRedisServer(port: number): Promise<RedisServer> {
       ],
     });
     const status = await process.status();
-    assert(status.success);
+    //assert(status.success);
     process.close();
     await delay(500);
     return {

--- a/tests/test_util.ts
+++ b/tests/test_util.ts
@@ -54,6 +54,8 @@ export async function startRedisServer(port: number): Promise<RedisServer> {
         "run",
         "--name",
         containerName,
+        "--port",
+        `${port}:${port}`,
         "-d",
         "redis",
         "redis-server",

--- a/tests/test_util.ts
+++ b/tests/test_util.ts
@@ -45,12 +45,13 @@ interface RedisServer {
 
 const USE_DOCKER = Deno.env.get("USE_DOCKER");
 const useDocker = USE_DOCKER === "1" || USE_DOCKER === "true";
+const dockerBin = Deno.env.get("DOCKER_BIN") ?? "docker";
 export async function startRedisServer(port: number): Promise<RedisServer> {
   if (useDocker) {
     const containerName = `redis-${port}`;
     const process = Deno.run({
       cmd: [
-        "docker",
+        dockerBin,
         "run",
         "--name",
         containerName,
@@ -70,7 +71,7 @@ export async function startRedisServer(port: number): Promise<RedisServer> {
     return {
       async dispose() {
         const process = Deno.run({
-          cmd: ["docker", "stop", containerName],
+          cmd: [dockerBin, "stop", containerName],
         });
         await process.status();
         process.close();

--- a/tests/test_util.ts
+++ b/tests/test_util.ts
@@ -63,7 +63,8 @@ export async function startRedisServer(port: number): Promise<RedisServer> {
         String(port),
       ],
     });
-    await process.status();
+    const status = await process.status();
+    assert(status.success);
     process.close();
     await delay(500);
     return {

--- a/tests/test_util.ts
+++ b/tests/test_util.ts
@@ -65,6 +65,7 @@ export async function startRedisServer(port: number): Promise<RedisServer> {
     });
     await process.status();
     process.close();
+    await delay(500);
     return {
       async dispose() {
         const process = Deno.run({


### PR DESCRIPTION
- [ ] use locally-installed redis instead of dockerized one.
- [ ] cache installed binary using [actions/cache](https://github.com/actions/cache).