### PR TITLE
ci: use locally-installed redis instead of dockerized one

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    services:
-      redis:
-        image: redis
-        ports:
-        - 6379:6379
     steps:
       - uses: actions/checkout@v1
       - name: Install Deno
@@ -29,6 +24,15 @@ jobs:
       - name: Run lint
         run: |
           make lint
+      - name: Install and start Redis
+        run: |
+          make testdeps
+          make start-redis
+          sleep 1
+          echo "::add-path::./testdata/redis/src"
       - name: Run Tests
         run: |
           make test      
+      - name: Kill Redis
+        run: |
+          make kill-redis

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 deno.d.ts
 .idea
 commands
+testdata/*/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+TESTDATA_DIR=testdata
+
 redis:
 	docker run -p 6379:6379 -d -t redis:5
 test:
@@ -5,3 +7,50 @@ test:
 lint:
 	deno fmt --check
 	deno lint --unstable
+
+# The following targets are adopted from go-redis (https://github.com/go-redis/redis/blob/dc52593c8c63bc2a05796ec44efd317fd3e14b64/Makefile):
+# * `testdeps`
+# * `${TESTDATA_DIR}/redis`
+# * `${TESTDATA_DIR}/redis/src/redis-server`
+#
+# Copyright (c) 2013 The github.com/go-redis/redis Authors.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#    * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+testdeps: ${TESTDATA_DIR}/redis/src/redis-server
+
+.PHONY: testdeps
+
+${TESTDATA_DIR}/redis:
+	mkdir -p $@
+	wget -qO- http://download.redis.io/releases/redis-6.0.5.tar.gz | tar xvz --strip-components=1 -C $@
+
+${TESTDATA_DIR}/redis/src/redis-server: ${TESTDATA_DIR}/redis
+	cd $< && make all
+
+start-redis:
+	${TESTDATA_DIR}/redis/src/redis-server --port 6379 --daemonize yes
+
+kill-redis:
+	${TESTDATA_DIR}/redis/src/redis-cli -p 6379 shutdown

--- a/tests/test_util.ts
+++ b/tests/test_util.ts
@@ -1,5 +1,6 @@
 import { Redis, connect, RedisConnectOptions } from "../redis.ts";
 import { assert } from "../vendor/https/deno.land/std/testing/asserts.ts";
+import { delay } from "../vendor/https/deno.land/std/async/mod.ts";
 
 function* dbIndex() {
   let i = 0;
@@ -35,4 +36,27 @@ export async function makeTest(
     });
   };
   return { test, client, opts };
+}
+
+interface StartRedisServerOptions {
+  port: number;
+}
+export async function startRedisServer(
+  options: StartRedisServerOptions,
+): Promise<Deno.Process> {
+  const { port } = options;
+  const process = Deno.run(
+    {
+      cmd: ["redis-server", "--port", port.toString()],
+      stdin: "null",
+      stdout: "null",
+    },
+  );
+  await waitForPort(port);
+  return process;
+}
+
+// FIXME!
+function waitForPort(_port: number): Promise<void> {
+  return delay(500);
 }


### PR DESCRIPTION
Towards #104 and #110.