### PR TITLE
chore: remove an unnecessary test for Redis.executor

### DIFF
--- a/tests/connection_test.ts
+++ b/tests/connection_test.ts
@@ -34,9 +34,4 @@ suite.test("swapdb", async () => {
   assertEquals(await client.swapdb(0, 1), "OK");
 });
 
-suite.test("executor", async () => {
-  const r = await client.executor.exec("EXISTS", "non-existing-key");
-  assertEquals(r, ["integer", 0]);
-});
-
 suite.runTests();


### PR DESCRIPTION
The tests for `Redis.executor` already exist in [`tests/general_test.ts`](https://github.com/denolib/deno-redis/blob/47d09695224bcc9aa662a9cdb260b18cf4e28c34/tests/general_test.ts#).