### PR TITLE
chore: improve commands API correctness

### DIFF
--- a/command.ts
+++ b/command.ts
@@ -173,9 +173,9 @@ export type RedisCommands = {
   incrbyfloat(key: string, increment: number): Promise<BulkString>;
   mget(key: string, ...keys: string[]): Promise<Bulk[]>;
   mset(key: string, value: string): Promise<Status>;
-  mset(...key_values: string[]): Promise<Status>;
+  mset(key_values: Record<string, string>): Promise<Status>;
   msetnx(key: string, value: string): Promise<Integer>;
-  msetnx(...key_values: string[]): Promise<Integer>;
+  msetnx(key_values: Record<string, string>): Promise<Integer>;
   psetex(key: string, milliseconds: number, value: string): Promise<Status>;
   set(
     key: string,
@@ -210,7 +210,7 @@ export type RedisCommands = {
   ): Promise<Integer>;
   geoadd(
     key: string,
-    ...longitude_latitude_member: [number, number, string][]
+    member_lng_lats: Record<string, [number, number]>,
   ): Promise<Integer>;
   geohash(key: string, member: string, ...members: string[]): Promise<Bulk[]>;
   geopos(
@@ -274,7 +274,7 @@ export type RedisCommands = {
   /** @deprecated >= 4.0.0 use hset */
   hmset(key: string, field: string, value: string): Promise<Status>;
   /** @deprecated >= 4.0.0 use hset */
-  hmset(key: string, ...field_values: string[]): Promise<Status>;
+  hmset(key: string, field_values: Record<string, string>): Promise<Status>;
   hscan(
     key: string,
     cursor: number,
@@ -284,7 +284,7 @@ export type RedisCommands = {
     },
   ): Promise<[BulkString, BulkString[]]>;
   hset(key: string, field: string, value: string): Promise<Integer>;
-  hset(key: string, ...field_values: string[]): Promise<Integer>;
+  hset(key: string, field_values: Record<string, string>): Promise<Integer>;
   hsetnx(key: string, field: string, value: string): Promise<Integer>;
   hstrlen(key: string, field: string): Promise<Integer>;
   hvals(key: string): Promise<BulkString[]>;
@@ -328,11 +328,11 @@ export type RedisCommands = {
     pattern: string,
     ...patterns: string[]
   ): Promise<RedisSubscription>;
-  pubsub_channels(pattern: string): Promise<BulkString[]>;
+  pubsub_channels(pattern?: string): Promise<BulkString[]>;
   pubsub_numsub(...channels: string[]): Promise<[BulkString, Integer][]>;
   pubsub_numpat(): Promise<Integer>;
   publish(channel: string, message: string): Promise<Integer>;
-  subscribe(...channels: string[]): Promise<RedisSubscription>;
+  subscribe(channel: string, ...channels: string[]): Promise<RedisSubscription>;
   // Set
   sadd(key: string, member: string, ...members: string[]): Promise<Integer>;
   scard(key: string): Promise<Integer>;
@@ -739,7 +739,7 @@ XRANGE somestream - +
   ): Promise<Integer>;
   zadd(
     key: string,
-    score_members: [number, string][],
+    member_scores: Record<string, number>,
     opts?: {
       mode?: "NX" | "XX";
       ch?: boolean;
@@ -758,7 +758,7 @@ XRANGE somestream - +
   ): Promise<Integer>;
   zinterstore(
     destination: string,
-    key_weights: [string, number][],
+    key_weights: Record<string, number>,
     opts?: {
       aggregate?: "SUM" | "MIN" | "MAX";
     },
@@ -852,7 +852,7 @@ XRANGE somestream - +
   ): Promise<Integer>;
   zunionstore(
     destination: string,
-    key_weights: [string, number][],
+    key_weights: Record<string, number>,
     opts?: {
       aggregate?: "SUM" | "MIN" | "MAX";
     },

--- a/command.ts
+++ b/command.ts
@@ -82,7 +82,7 @@ export type RedisCommands = {
     key: string,
     ttl: number,
     serialized_value: string,
-    opt?: {
+    opts?: {
       replace?: boolean;
       absttl?: boolean;
       idletime?: number;
@@ -721,12 +721,12 @@ XRANGE somestream - +
     timeout: number,
     key: string,
     ...keys: string[]
-  ): Promise<[BulkString, BulkString, BulkString] | []>;
+  ): Promise<[BulkString, BulkString, BulkString]>;
   bzpopmax(
     timeout: number,
     key: string,
     ...keys: string[]
-  ): Promise<[BulkString, BulkString, BulkString] | []>;
+  ): Promise<[BulkString, BulkString, BulkString]>;
   zadd(
     key: string,
     score: number,
@@ -901,7 +901,7 @@ XRANGE somestream - +
   bgrewriteaof(): Promise<Status>;
   bgsave(): Promise<Status>;
   command(): Promise<
-    [BulkString, Integer, BulkString[], Integer, Integer, Integer]
+    [BulkString, Integer, BulkString[], Integer, Integer, Integer][]
   >;
   command_count(): Promise<Integer>;
   command_getkeys(): Promise<BulkString[]>;
@@ -956,7 +956,7 @@ XRANGE somestream - +
     | ["sentinel", BulkString[]]
   >;
   save(): Promise<Status>;
-  shutdown(mode: "NOSAVE" | "SAVE"): Promise<Status>;
+  shutdown(mode?: "NOSAVE" | "SAVE"): Promise<Status>;
   slaveof(host: string, port: number): Promise<Status>;
   slaveof_noone(): Promise<Status>;
   slowlog(subcommand: string, ...args: string[]): Promise<ConditionalArray>;

--- a/command.ts
+++ b/command.ts
@@ -164,8 +164,10 @@ export type RedisCommands = {
   incrbyfloat(key: string, increment: number): Promise<BulkString>;
   mget(...keys: string[]): Promise<Bulk[]>;
   mset(key: string, value: string): Promise<Status>;
+  mset(...key_values: [string, string][]): Promise<Status>;
   mset(key_values: Record<string, string>): Promise<Status>;
   msetnx(key: string, value: string): Promise<Integer>;
+  msetnx(...key_values: [string, string][]): Promise<Integer>;
   msetnx(key_values: Record<string, string>): Promise<Integer>;
   psetex(key: string, milliseconds: number, value: string): Promise<Status>;
   set(
@@ -190,6 +192,10 @@ export type RedisCommands = {
     longitude: number,
     latitude: number,
     member: string,
+  ): Promise<Integer>;
+  geoadd(
+    key: string,
+    ...lng_lat_members: [number, number, string][]
   ): Promise<Integer>;
   geoadd(
     key: string,
@@ -261,6 +267,10 @@ export type RedisCommands = {
   /**
    * @deprecated since 4.0.0, use hset
    */
+  hmset(key: string, ...field_values: [string, string][]): Promise<Status>;
+  /**
+   * @deprecated since 4.0.0, use hset
+   */
   hmset(key: string, field_values: Record<string, string>): Promise<Status>;
   hscan(
     key: string,
@@ -268,6 +278,7 @@ export type RedisCommands = {
     opts?: { pattern?: string; count?: number },
   ): Promise<[BulkString, BulkString[]]>;
   hset(key: string, field: string, value: string): Promise<Integer>;
+  hset(key: string, ...field_values: [string, string][]): Promise<Integer>;
   hset(key: string, field_values: Record<string, string>): Promise<Integer>;
   hsetnx(key: string, field: string, value: string): Promise<Integer>;
   hstrlen(key: string, field: string): Promise<Integer>;
@@ -707,6 +718,11 @@ XRANGE somestream - +
   ): Promise<Integer>;
   zadd(
     key: string,
+    score_members: [number, string][],
+    opts?: { mode?: "NX" | "XX"; ch?: boolean },
+  ): Promise<Integer>;
+  zadd(
+    key: string,
     member_scores: Record<string, number>,
     opts?: { mode?: "NX" | "XX"; ch?: boolean },
   ): Promise<Integer>;
@@ -722,6 +738,11 @@ XRANGE somestream - +
   zinterstore(
     destination: string,
     keys: string[],
+    opts?: { aggregate?: "SUM" | "MIN" | "MAX" },
+  ): Promise<Integer>;
+  zinterstore(
+    destination: string,
+    key_weights: [string, number][],
     opts?: { aggregate?: "SUM" | "MIN" | "MAX" },
   ): Promise<Integer>;
   zinterstore(
@@ -787,6 +808,11 @@ XRANGE somestream - +
   zunionstore(
     destination: string,
     keys: string[],
+    opts?: { aggregate?: "SUM" | "MIN" | "MAX" },
+  ): Promise<Integer>;
+  zunionstore(
+    destination: string,
+    key_weights: [string, number][],
     opts?: { aggregate?: "SUM" | "MIN" | "MAX" },
   ): Promise<Integer>;
   zunionstore(
@@ -871,7 +897,7 @@ XRANGE somestream - +
   module_unload(name: string): Promise<Status>;
   monitor(): void;
   replicaof(host: string, port: number): Promise<Status>;
-  replicaof_none(): Promise<Status>;
+  replicaof_no_one(): Promise<Status>;
   role(): Promise<
     | ["master", Integer, BulkString[][]]
     | ["slave", BulkString, Integer, BulkString, Integer]
@@ -880,7 +906,7 @@ XRANGE somestream - +
   save(): Promise<Status>;
   shutdown(mode?: "NOSAVE" | "SAVE"): Promise<Status>;
   slaveof(host: string, port: number): Promise<Status>;
-  slaveof_none(): Promise<Status>;
+  slaveof_no_one(): Promise<Status>;
   slowlog(subcommand: string, ...args: string[]): Promise<ConditionalArray>;
   swapdb(index1: number, index2: number): Promise<Status>;
   sync(): void;

--- a/redis.ts
+++ b/redis.ts
@@ -130,8 +130,8 @@ export class RedisImpl implements Redis {
     return this.execArrayReply<BulkString>("ACL", "CAT");
   }
 
-  acl_deluser(username: string, ...usernames: string[]) {
-    return this.execIntegerReply("ACL", "DELUSER", username, ...usernames);
+  acl_deluser(...usernames: string[]) {
+    return this.execIntegerReply("ACL", "DELUSER", ...usernames);
   }
 
   acl_genpass(bits?: number) {
@@ -240,8 +240,8 @@ export class RedisImpl implements Redis {
     return this.execArrayReply<Integer>("BITFIELD", ...args);
   }
 
-  bitop(operation: string, destkey: string, key: string, ...keys: string[]) {
-    return this.execIntegerReply("BITOP", operation, destkey, key, ...keys);
+  bitop(operation: string, destkey: string, ...keys: string[]) {
+    return this.execIntegerReply("BITOP", operation, destkey, ...keys);
   }
 
   bitpos(key: string, bit: number, start?: number, end?: number) {
@@ -254,32 +254,36 @@ export class RedisImpl implements Redis {
     return this.execIntegerReply("BITPOS", key, bit);
   }
 
-  blpop(timeout: number, key: string, ...keys: string[]) {
-    return this.execArrayReply<Bulk>("BLPOP", key, ...keys, timeout);
+  blpop(timeout: number, ...keys: string[]) {
+    return this.execArrayReply("BLPOP", ...keys, timeout) as Promise<
+      [BulkString, BulkString] | []
+    >;
   }
 
-  brpop(timeout: number, key: string, ...keys: string[]) {
-    return this.execArrayReply<Bulk>("BRPOP", key, ...keys, timeout);
+  brpop(timeout: number, ...keys: string[]) {
+    return this.execArrayReply("BRPOP", ...keys, timeout) as Promise<
+      [BulkString, BulkString] | []
+    >;
   }
 
   brpoplpush(source: string, destination: string, timeout: number) {
     return this.execBulkReply("BRPOPLPUSH", source, destination, timeout);
   }
 
-  bzpopmin(timeout: number, key: string, ...keys: string[]) {
-    return this.execArrayReply("BZPOPMIN", key, ...keys, timeout) as Promise<
-      [BulkString, BulkString, BulkString]
+  bzpopmin(timeout: number, ...keys: string[]) {
+    return this.execArrayReply("BZPOPMIN", ...keys, timeout) as Promise<
+      [BulkString, BulkString, BulkString] | []
     >;
   }
 
-  bzpopmax(timeout: number, key: string, ...keys: string[]) {
-    return this.execArrayReply("BZPOPMAX", key, ...keys, timeout) as Promise<
-      [BulkString, BulkString, BulkString]
+  bzpopmax(timeout: number, ...keys: string[]) {
+    return this.execArrayReply("BZPOPMAX", ...keys, timeout) as Promise<
+      [BulkString, BulkString, BulkString] | []
     >;
   }
 
-  cluster_addslots(slot: number, ...slots: number[]) {
-    return this.execStatusReply("CLUSTER", "ADDSLOTS", slot, ...slots);
+  cluster_addslots(...slots: number[]) {
+    return this.execStatusReply("CLUSTER", "ADDSLOTS", ...slots);
   }
 
   cluster_countfailurereports(node_id: string) {
@@ -290,8 +294,8 @@ export class RedisImpl implements Redis {
     return this.execIntegerReply("CLUSTER", "COUNTKEYSINSLOT", slot);
   }
 
-  cluster_delslots(slot: number, ...slots: number[]) {
-    return this.execStatusReply("CLUSTER", "DELSLOTS", slot, ...slots);
+  cluster_delslots(...slots: number[]) {
+    return this.execStatusReply("CLUSTER", "DELSLOTS", ...slots);
   }
 
   cluster_failover(mode?: "FORCE" | "TAKEOVER") {
@@ -396,23 +400,10 @@ export class RedisImpl implements Redis {
     return this.execArrayReply<BulkString>("COMMAND", "GETKEYS");
   }
 
-  command_info(command_name: string, ...command_names: string[]) {
-    return this.execArrayReply(
-      "COMMAND",
-      "INFO",
-      command_name,
-      ...command_names,
-    ) as Promise<
+  command_info(...command_names: string[]) {
+    return this.execArrayReply("COMMAND", "INFO", ...command_names) as Promise<
       (
-        | [
-          BulkString,
-          Integer,
-          BulkString[],
-          Integer,
-          Integer,
-          Integer,
-          BulkString[],
-        ]
+        | [BulkString, Integer, BulkString[], Integer, Integer, Integer]
         | BulkNil
       )[]
     >;
@@ -454,8 +445,8 @@ export class RedisImpl implements Redis {
     return this.execIntegerReply("DECRBY", key, decrement);
   }
 
-  del(key: string, ...keys: string[]) {
-    return this.execIntegerReply("DEL", key, ...keys);
+  del(...keys: string[]) {
+    return this.execIntegerReply("DEL", ...keys);
   }
 
   discard() {
@@ -496,8 +487,8 @@ export class RedisImpl implements Redis {
     return this.execArrayReply("EXEC");
   }
 
-  exists(key: string, ...keys: string[]) {
-    return this.execIntegerReply("EXISTS", key, ...keys);
+  exists(...keys: string[]) {
+    return this.execIntegerReply("EXISTS", ...keys);
   }
 
   expire(key: string, seconds: number) {
@@ -543,13 +534,13 @@ export class RedisImpl implements Redis {
     return this.execIntegerReply("GEOADD", ...args);
   }
 
-  geohash(key: string, member: string, ...members: string[]) {
-    return this.execArrayReply<Bulk>("GEOHASH", key, member, ...members);
+  geohash(key: string, ...members: string[]) {
+    return this.execArrayReply<Bulk>("GEOHASH", key, ...members);
   }
 
-  geopos(key: string, member: string, ...members: string[]) {
-    return this.execArrayReply("GEOPOS", key, member, ...members) as Promise<
-      ([Integer, Integer] | BulkNil)[]
+  geopos(key: string, ...members: string[]) {
+    return this.execArrayReply("GEOPOS", key, ...members) as Promise<
+      ([BulkString, BulkString] | BulkNil)[]
     >;
   }
 
@@ -619,7 +610,6 @@ export class RedisImpl implements Redis {
       store_dist?: string;
     },
   ) {
-    if (!opts) return args;
     if (opts?.with_coord) {
       args.push("WITHCOORD");
     }
@@ -660,8 +650,8 @@ export class RedisImpl implements Redis {
     return this.execBulkReply("GETSET", key, value);
   }
 
-  hdel(key: string, field: string, ...fields: string[]) {
-    return this.execIntegerReply("HDEL", key, field, ...fields);
+  hdel(key: string, ...fields: string[]) {
+    return this.execIntegerReply("HDEL", key, ...fields);
   }
 
   hexists(key: string, field: string) {
@@ -697,8 +687,8 @@ export class RedisImpl implements Redis {
     return this.execIntegerReply("HLEN", key);
   }
 
-  hmget(key: string, field: string, ...fields: string[]) {
-    return this.execArrayReply<Bulk>("HMGET", key, field, ...fields);
+  hmget(key: string, ...fields: string[]) {
+    return this.execArrayReply<Bulk>("HMGET", key, ...fields);
   }
 
   hmset(
@@ -788,20 +778,12 @@ export class RedisImpl implements Redis {
     return this.execBulkReply("LPOP", key);
   }
 
-  lpush(
-    key: string,
-    element: string | number,
-    ...elements: (string | number)[]
-  ) {
-    return this.execIntegerReply("LPUSH", key, element, ...elements);
+  lpush(key: string, ...elements: (string | number)[]) {
+    return this.execIntegerReply("LPUSH", key, ...elements);
   }
 
-  lpushx(
-    key: string,
-    element: string | number,
-    ...elements: (string | number)[]
-  ) {
-    return this.execIntegerReply("LPUSHX", key, element, ...elements);
+  lpushx(key: string, ...elements: (string | number)[]) {
+    return this.execIntegerReply("LPUSHX", key, ...elements);
   }
 
   lrange(key: string, start: number, stop: number) {
@@ -840,12 +822,7 @@ export class RedisImpl implements Redis {
     return this.execArrayReply("MEMORY", "STATS");
   }
 
-  memory_usage(
-    key: string,
-    opts?: {
-      samples?: number;
-    },
-  ) {
+  memory_usage(key: string, opts?: { samples?: number }) {
     const args: (number | string)[] = [key];
     if (opts?.samples !== undefined) {
       args.push("SAMPLES", opts.samples);
@@ -853,8 +830,8 @@ export class RedisImpl implements Redis {
     return this.execIntegerReply("MEMORY", "USAGE", ...args);
   }
 
-  mget(key: string, ...keys: string[]) {
-    return this.execArrayReply<Bulk>("MGET", key, ...keys);
+  mget(...keys: string[]) {
+    return this.execArrayReply<Bulk>("MGET", ...keys);
   }
 
   migrate(
@@ -966,16 +943,16 @@ export class RedisImpl implements Redis {
     return this.execIntegerReply("PEXPIREAT", key, milliseconds_timestamp);
   }
 
-  pfadd(key: string, element: string, ...elements: string[]) {
-    return this.execIntegerReply("PFADD", key, element, ...elements);
+  pfadd(key: string, ...elements: string[]) {
+    return this.execIntegerReply("PFADD", key, ...elements);
   }
 
-  pfcount(key: string, ...keys: string[]) {
-    return this.execIntegerReply("PFCOUNT", key, ...keys);
+  pfcount(...keys: string[]) {
+    return this.execIntegerReply("PFCOUNT", ...keys);
   }
 
-  pfmerge(destkey: string, sourcekey: string, ...sourcekeys: string[]) {
-    return this.execStatusReply("PFMERGE", destkey, sourcekey, ...sourcekeys);
+  pfmerge(destkey: string, ...sourcekeys: string[]) {
+    return this.execStatusReply("PFMERGE", destkey, ...sourcekeys);
   }
 
   ping(message?: string) {
@@ -993,12 +970,12 @@ export class RedisImpl implements Redis {
     return this.execIntegerReply("PUBLISH", channel, message);
   }
 
-  subscribe(channel: string, ...channels: string[]) {
-    return subscribe(this.connection, channel, ...channels);
+  subscribe(...channels: string[]) {
+    return subscribe(this.connection, ...channels);
   }
 
-  psubscribe(pattern: string, ...patterns: string[]) {
-    return psubscribe(this.connection, pattern, ...patterns);
+  psubscribe(...patterns: string[]) {
+    return psubscribe(this.connection, ...patterns);
   }
 
   pubsub_channels(pattern?: string) {
@@ -1013,9 +990,11 @@ export class RedisImpl implements Redis {
   }
 
   pubsub_numsub(...channels: string[]) {
-    return this.execArrayReply("PUBSUB", "NUMSUBS", ...channels) as Promise<
-      [BulkString, Integer][]
-    >;
+    return this.execArrayReply<BulkString | Integer>(
+      "PUBSUB",
+      "NUMSUBS",
+      ...channels,
+    );
   }
 
   pttl(key: string) {
@@ -1089,24 +1068,16 @@ export class RedisImpl implements Redis {
     return this.execBulkReply("RPOPLPUSH", source, destination);
   }
 
-  rpush(
-    key: string,
-    element: string | number,
-    ...elements: (string | number)[]
-  ) {
-    return this.execIntegerReply("RPUSH", key, element, ...elements);
+  rpush(key: string, ...elements: (string | number)[]) {
+    return this.execIntegerReply("RPUSH", key, ...elements);
   }
 
-  rpushx(
-    key: string,
-    element: string | number,
-    ...elements: (string | number)[]
-  ) {
-    return this.execIntegerReply("RPUSHX", key, element, ...elements);
+  rpushx(key: string, ...elements: (string | number)[]) {
+    return this.execIntegerReply("RPUSHX", key, ...elements);
   }
 
-  sadd(key: string, member: string, ...members: string[]) {
-    return this.execIntegerReply("SADD", key, member, ...members);
+  sadd(key: string, ...members: string[]) {
+    return this.execIntegerReply("SADD", key, ...members);
   }
 
   save() {
@@ -1121,8 +1092,8 @@ export class RedisImpl implements Redis {
     return this.execStatusReply("SCRIPT", "DEBUG", mode);
   }
 
-  script_exists(sha1: string, ...sha1s: string[]) {
-    return this.execArrayReply<Integer>("SCRIPT", "EXISTS", sha1, ...sha1s);
+  script_exists(...sha1s: string[]) {
+    return this.execArrayReply<Integer>("SCRIPT", "EXISTS", ...sha1s);
   }
 
   script_flush() {
@@ -1137,12 +1108,12 @@ export class RedisImpl implements Redis {
     return this.execStatusReply("SCRIPT", "LOAD", script);
   }
 
-  sdiff(key: string, ...keys: string[]) {
-    return this.execArrayReply<BulkString>("SDIFF", key, ...keys);
+  sdiff(...keys: string[]) {
+    return this.execArrayReply<BulkString>("SDIFF", ...keys);
   }
 
-  sdiffstore(destination: string, key: string, ...keys: string[]) {
-    return this.execIntegerReply("SDIFFSTORE", destination, key, ...keys);
+  sdiffstore(destination: string, ...keys: string[]) {
+    return this.execIntegerReply("SDIFFSTORE", destination, ...keys);
   }
 
   select(index: number) {
@@ -1152,36 +1123,22 @@ export class RedisImpl implements Redis {
   set(
     key: string,
     value: string,
-    opts?: {
-      ex?: number;
-      px?: number;
-      keepttl?: boolean;
-    },
+    opts?: { ex?: number; px?: number; keepttl?: boolean },
   ): Promise<Status>;
   set(
     key: string,
     value: string,
-    opts: {
-      ex?: number;
-      px?: number;
-      keepttl?: boolean;
-      mode: "NX" | "XX";
-    },
+    opts?: { ex?: number; px?: number; keepttl?: boolean; mode: "NX" | "XX" },
   ): Promise<Status | BulkNil>;
   set(
     key: string,
     value: string,
-    opts?: {
-      ex?: number;
-      px?: number;
-      keepttl?: boolean;
-      mode?: "NX" | "XX";
-    },
+    opts?: { ex?: number; px?: number; keepttl?: boolean; mode?: "NX" | "XX" },
   ) {
     const args: (number | string)[] = [key, value];
-    if (opts?.ex) {
+    if (opts?.ex !== undefined) {
       args.push("EX", opts.ex);
-    } else if (opts?.px) {
+    } else if (opts?.px !== undefined) {
       args.push("PX", opts.px);
     }
     if (opts?.keepttl) {
@@ -1217,12 +1174,12 @@ export class RedisImpl implements Redis {
     return this.execStatusReply("SHUTDOWN");
   }
 
-  sinter(key: string, ...keys: string[]) {
-    return this.execArrayReply<BulkString>("SINTER", key, ...keys);
+  sinter(...keys: string[]) {
+    return this.execArrayReply<BulkString>("SINTER", ...keys);
   }
 
-  sinterstore(destination: string, key: string, ...keys: string[]) {
-    return this.execIntegerReply("SINTERSTORE", destination, key, ...keys);
+  sinterstore(destination: string, ...keys: string[]) {
+    return this.execIntegerReply("SINTERSTORE", destination, ...keys);
   }
 
   sismember(key: string, member: string) {
@@ -1233,7 +1190,7 @@ export class RedisImpl implements Redis {
     return this.execStatusReply("SLAVEOF", host, port);
   }
 
-  slaveof_noone() {
+  slaveof_none() {
     return this.execStatusReply("SLAVEOF", "NO ONE");
   }
 
@@ -1241,7 +1198,7 @@ export class RedisImpl implements Redis {
     return this.execStatusReply("REPLICAOF", host, port);
   }
 
-  replicaof_noone() {
+  replicaof_none() {
     return this.execStatusReply("REPLICAOF", "NO ONE");
   }
 
@@ -1261,10 +1218,7 @@ export class RedisImpl implements Redis {
     key: string,
     opts?: {
       by?: string;
-      limit?: {
-        offset: number;
-        count: number;
-      };
+      limit?: { offset: number; count: number };
       patterns?: string[];
       order?: "ASC" | "DESC";
       alpha?: boolean;
@@ -1274,28 +1228,22 @@ export class RedisImpl implements Redis {
     key: string,
     opts?: {
       by?: string;
-      limit?: {
-        offset: number;
-        count: number;
-      };
+      limit?: { offset: number; count: number };
       patterns?: string[];
       order?: "ASC" | "DESC";
       alpha?: boolean;
-      store: string;
+      destination: string;
     },
   ): Promise<Integer>;
   sort(
     key: string,
     opts?: {
       by?: string;
-      limit?: {
-        offset: number;
-        count: number;
-      };
+      limit?: { offset: number; count: number };
       patterns?: string[];
       order?: "ASC" | "DESC";
       alpha?: boolean;
-      store?: string;
+      destination?: string;
     },
   ) {
     const args: (number | string)[] = [key];
@@ -1314,8 +1262,8 @@ export class RedisImpl implements Redis {
     if (opts?.alpha) {
       args.push("ALPHA");
     }
-    if (opts?.store !== undefined) {
-      args.push("STORE", opts.store);
+    if (opts?.destination !== undefined) {
+      args.push("STORE", opts.destination);
       return this.execIntegerReply("SORT", ...args);
     }
     return this.execArrayReply<BulkString>("SORT", ...args);
@@ -1339,20 +1287,20 @@ export class RedisImpl implements Redis {
     return this.execBulkReply("SRANDMEMBER", key);
   }
 
-  srem(key: string, member: string, ...members: string[]) {
-    return this.execIntegerReply("SREM", key, member, ...members);
+  srem(key: string, ...members: string[]) {
+    return this.execIntegerReply("SREM", key, ...members);
   }
 
   strlen(key: string) {
     return this.execIntegerReply("STRLEN", key);
   }
 
-  sunion(key: string, ...keys: string[]) {
-    return this.execArrayReply<BulkString>("SUNION", key, ...keys);
+  sunion(...keys: string[]) {
+    return this.execArrayReply<BulkString>("SUNION", ...keys);
   }
 
-  sunionstore(destination: string, key: string, ...keys: string[]) {
-    return this.execIntegerReply("SUNIONSTORE", destination, key, ...keys);
+  sunionstore(destination: string, ...keys: string[]) {
+    return this.execIntegerReply("SUNIONSTORE", destination, ...keys);
   }
 
   swapdb(index1: number, index2: number) {
@@ -1367,8 +1315,8 @@ export class RedisImpl implements Redis {
     return this.execArrayReply("TIME") as Promise<[BulkString, BulkString]>;
   }
 
-  touch(key: string, ...keys: string[]) {
-    return this.execIntegerReply("TOUCH", key, ...keys);
+  touch(...keys: string[]) {
+    return this.execIntegerReply("TOUCH", ...keys);
   }
 
   ttl(key: string) {
@@ -1379,8 +1327,8 @@ export class RedisImpl implements Redis {
     return this.execStatusReply("TYPE", key);
   }
 
-  unlink(key: string, ...keys: string[]) {
-    return this.execIntegerReply("UNLINK", key, ...keys);
+  unlink(...keys: string[]) {
+    return this.execIntegerReply("UNLINK", ...keys);
   }
 
   unwatch() {
@@ -1391,8 +1339,8 @@ export class RedisImpl implements Redis {
     return this.execIntegerReply("WAIT", numreplicas, timeout);
   }
 
-  watch(key: string, ...keys: string[]) {
-    return this.execStatusReply("WATCH", key, ...keys);
+  watch(...keys: string[]) {
+    return this.execStatusReply("WATCH", ...keys);
   }
 
   xack(key: string, group: string, ...xids: XIdInput[]) {
@@ -1823,26 +1771,26 @@ export class RedisImpl implements Redis {
     return this.execIntegerReply("XTRIM", key, "MAXLEN", ...args);
   }
 
-  // deno-lint-ignore no-explicit-any
   zadd(
     key: string,
     score_or_record: number | Record<string, number>,
-    member_or_opts: any,
-    opts?: {
-      mode?: "NX" | "XX";
-      ch?: boolean;
-      incr?: boolean;
-    },
+    member_or_opts?: string | { mode?: "NX" | "XX"; ch?: boolean },
+    opts?: { mode?: "NX" | "XX"; ch?: boolean },
   ) {
     const args: (string | number)[] = [key];
-    if (typeof score_or_record === "number") {
+    if (
+      typeof score_or_record === "number" &&
+      typeof member_or_opts === "string"
+    ) {
       args.push(score_or_record);
       args.push(member_or_opts);
     } else {
       for (let [member, score] of Object.entries(score_or_record)) {
         args.push(score, member);
       }
-      opts = member_or_opts;
+      if (typeof member_or_opts === "object") {
+        opts = member_or_opts;
+      }
     }
     if (opts?.mode) {
       args.push(opts.mode);
@@ -1850,10 +1798,24 @@ export class RedisImpl implements Redis {
     if (opts?.ch) {
       args.push("CH");
     }
-    if (opts?.incr) {
-      args.push("INCR");
-    }
     return this.execIntegerReply("ZADD", ...args);
+  }
+
+  zadd_incr(
+    key: string,
+    score: number,
+    member: string,
+    opts?: { mode?: "NX" | "XX"; ch?: boolean },
+  ) {
+    const args: (string | number)[] = [key, score, member];
+    if (opts?.mode) {
+      args.push(opts.mode);
+    }
+    if (opts?.ch) {
+      args.push("CH");
+    }
+    args.push("INCR");
+    return this.execBulkReply("ZADD", ...args);
   }
 
   zcard(key: string) {
@@ -1871,9 +1833,7 @@ export class RedisImpl implements Redis {
   zinterstore(
     destination: string,
     keys_or_record: string[] | Record<string, number>,
-    opts?: {
-      aggregate?: "SUM" | "MIN" | "MAX";
-    },
+    opts?: { aggregate?: "SUM" | "MIN" | "MAX" },
   ) {
     const args = this.pushZStoreArgs([destination], keys_or_record, opts);
     return this.execIntegerReply("ZINTERSTORE", ...args);
@@ -1882,9 +1842,7 @@ export class RedisImpl implements Redis {
   zunionstore(
     destination: string,
     keys_or_record: string[] | Record<string, number>,
-    opts?: {
-      aggregate?: "SUM" | "MIN" | "MAX";
-    },
+    opts?: { aggregate?: "SUM" | "MIN" | "MAX" },
   ) {
     const args = this.pushZStoreArgs([destination], keys_or_record, opts);
     return this.execIntegerReply("ZUNIONSTORE", ...args);
@@ -1893,9 +1851,7 @@ export class RedisImpl implements Redis {
   private pushZStoreArgs(
     args: (number | string)[],
     keys_or_record: string[] | Record<string, number>,
-    opts?: {
-      aggregate?: "SUM" | "MIN" | "MAX";
-    },
+    opts?: { aggregate?: "SUM" | "MIN" | "MAX" },
   ) {
     if (Array.isArray(keys_or_record)) {
       args.push(keys_or_record.length, ...keys_or_record);
@@ -1933,9 +1889,7 @@ export class RedisImpl implements Redis {
     key: string,
     start: number,
     stop: number,
-    opts?: {
-      with_score?: boolean;
-    },
+    opts?: { with_score?: boolean },
   ) {
     const args = this.pushZRangeOpts([key, start, stop], opts);
     return this.execArrayReply<BulkString>("ZRANGE", ...args);
@@ -1945,12 +1899,7 @@ export class RedisImpl implements Redis {
     key: string,
     min: string,
     max: string,
-    opts?: {
-      limit?: {
-        offset: number;
-        count: number;
-      };
-    },
+    opts?: { limit?: { offset: number; count: number } },
   ) {
     const args = this.pushZRangeOpts([key, min, max], opts);
     return this.execArrayReply<BulkString>("ZRANGEBYLEX", ...args);
@@ -1958,15 +1907,9 @@ export class RedisImpl implements Redis {
 
   zrangebyscore(
     key: string,
-    min: string,
-    max: string,
-    opts?: {
-      with_score?: boolean;
-      limit?: {
-        offset: number;
-        count: number;
-      };
-    },
+    min: number | string,
+    max: number | string,
+    opts?: { with_score?: boolean; limit?: { offset: number; count: number } },
   ) {
     const args = this.pushZRangeOpts([key, min, max], opts);
     return this.execArrayReply<BulkString>("ZRANGEBYSCORE", ...args);
@@ -1976,8 +1919,8 @@ export class RedisImpl implements Redis {
     return this.execIntegerOrNilReply("ZRANK", key, member);
   }
 
-  zrem(key: string, member: string, ...members: string[]) {
-    return this.execIntegerReply("ZREM", key, member, ...members);
+  zrem(key: string, ...members: string[]) {
+    return this.execIntegerReply("ZREM", key, ...members);
   }
 
   zremrangebylex(key: string, min: string, max: string) {
@@ -1988,7 +1931,7 @@ export class RedisImpl implements Redis {
     return this.execIntegerReply("ZREMRANGEBYRANK", key, start, stop);
   }
 
-  zremrangebyscore(key: string, min: number, max: number) {
+  zremrangebyscore(key: string, min: number | string, max: number | string) {
     return this.execIntegerReply("ZREMRANGEBYSCORE", key, min, max);
   }
 
@@ -1996,9 +1939,7 @@ export class RedisImpl implements Redis {
     key: string,
     start: number,
     stop: number,
-    opts?: {
-      with_score?: boolean;
-    },
+    opts?: { with_score?: boolean },
   ) {
     const args = this.pushZRangeOpts([key, start, stop], opts);
     return this.execArrayReply<BulkString>("ZREVRANGE", ...args);
@@ -2008,12 +1949,7 @@ export class RedisImpl implements Redis {
     key: string,
     max: string,
     min: string,
-    opts?: {
-      limit?: {
-        offset: number;
-        count: number;
-      };
-    },
+    opts?: { limit?: { offset: number; count: number } },
   ) {
     const args = this.pushZRangeOpts([key, min, max], opts);
     return this.execArrayReply<BulkString>("ZREVRANGEBYLEX", ...args);
@@ -2023,13 +1959,7 @@ export class RedisImpl implements Redis {
     key: string,
     max: number,
     min: number,
-    opts?: {
-      with_score?: boolean;
-      limit?: {
-        offset: number;
-        count: number;
-      };
-    },
+    opts?: { with_score?: boolean; limit?: { offset: number; count: number } },
   ) {
     const args = this.pushZRangeOpts([key, max, min], opts);
     return this.execArrayReply<BulkString>("ZREVRANGEBYSCORE", ...args);
@@ -2037,19 +1967,13 @@ export class RedisImpl implements Redis {
 
   private pushZRangeOpts(
     args: (number | string)[],
-    opts?: {
-      with_score?: boolean;
-      limit?: {
-        offset: number;
-        count: number;
-      };
-    },
+    opts?: { with_score?: boolean; limit?: { offset: number; count: number } },
   ) {
     if (opts?.with_score) {
       args.push("WITHSCORES");
     }
     if (opts?.limit) {
-      args.push("LIMIT", opts?.limit.offset, opts?.limit.count);
+      args.push("LIMIT", opts.limit.offset, opts.limit.count);
     }
     return args;
   }
@@ -2064,10 +1988,7 @@ export class RedisImpl implements Redis {
 
   scan(
     cursor: number,
-    opts?: {
-      pattern?: string;
-      count?: number;
-    },
+    opts?: { pattern?: string; count?: number; type?: string },
   ) {
     const args = this.pushScanOpts([cursor], opts);
     return this.execArrayReply("SCAN", ...args) as Promise<
@@ -2078,10 +1999,7 @@ export class RedisImpl implements Redis {
   sscan(
     key: string,
     cursor: number,
-    opts?: {
-      pattern?: string;
-      count?: number;
-    },
+    opts?: { pattern?: string; count?: number },
   ) {
     const args = this.pushScanOpts([key, cursor], opts);
     return this.execArrayReply("SSCAN", ...args) as Promise<
@@ -2092,10 +2010,7 @@ export class RedisImpl implements Redis {
   hscan(
     key: string,
     cursor: number,
-    opts?: {
-      pattern?: string;
-      count?: number;
-    },
+    opts?: { pattern?: string; count?: number },
   ) {
     const args = this.pushScanOpts([key, cursor], opts);
     return this.execArrayReply("HSCAN", ...args) as Promise<
@@ -2106,9 +2021,7 @@ export class RedisImpl implements Redis {
   zscan(
     key: string,
     cursor: number,
-    opts?: {
-      pattern?: string;
-    },
+    opts?: { pattern?: string; count?: number },
   ) {
     const args = this.pushScanOpts([key, cursor], opts);
     return this.execArrayReply("ZSCAN", ...args) as Promise<
@@ -2118,16 +2031,16 @@ export class RedisImpl implements Redis {
 
   private pushScanOpts(
     args: (number | string)[],
-    opts?: {
-      pattern?: string;
-      count?: number;
-    },
+    opts?: { pattern?: string; count?: number; type?: string },
   ) {
-    if (opts?.pattern) {
+    if (opts?.pattern !== undefined) {
       args.push("MATCH", opts.pattern);
     }
     if (opts?.count !== undefined) {
       args.push("COUNT", opts.count);
+    }
+    if (opts?.type !== undefined) {
+      args.push("TYPE", opts.type);
     }
     return args;
   }

--- a/redis.ts
+++ b/redis.ts
@@ -513,24 +513,18 @@ export class RedisImpl implements Redis {
     return this.execStatusReply("FLUSHDB");
   }
 
-  geoadd(
-    key: string,
-    lng_or_record: number | Record<string, [number, number]>,
-    lat?: number,
-    member?: string,
-  ) {
-    const args: (number | string)[] = [key];
-    if (
-      typeof lng_or_record === "number" &&
-      lat !== undefined &&
-      member !== undefined
-    ) {
-      args.push(lng_or_record, lat, member);
-    } else {
-      for (let [member, [lng, lat]] of Object.entries(lng_or_record)) {
-        args.push(lng, lat, member);
+  // deno-lint-ignore no-explicit-any
+  geoadd(key: string, ...params: any[]) {
+    const args: (string | number)[] = [key];
+    if (Array.isArray(params[0])) {
+      args.push(...params.flatMap((e) => e));
+    } else if (typeof params[0] === "object") {
+      for (let [member, lnglat] of Object.entries(params[0])) {
+        args.push(...(lnglat as [number, number]), member);
       }
-    }
+    } else {
+      args.push(...params);
+      }
     return this.execIntegerReply("GEOADD", ...args);
   }
 
@@ -691,35 +685,33 @@ export class RedisImpl implements Redis {
     return this.execArrayReply<Bulk>("HMGET", key, ...fields);
   }
 
-  hmset(
-    key: string,
-    field_or_record: string | Record<string, string>,
-    value?: string,
-  ) {
+  // deno-lint-ignore no-explicit-any
+  hmset(key: string, ...params: any[]) {
     const args = [key];
-    if (typeof field_or_record === "string" && value !== undefined) {
-      args.push(field_or_record, value);
-    } else {
-      for (let [field, value] of Object.entries(field_or_record)) {
-        args.push(field, value);
+    if (Array.isArray(params[0])) {
+      args.push(...params.flatMap((e) => e));
+    } else if (typeof params[0] === "object") {
+      for (let [field, value] of Object.entries(params[0])) {
+        args.push(field, value as string);
       }
-    }
+    } else {
+      args.push(...params);
+      }
     return this.execStatusReply("HMSET", ...args);
   }
 
-  hset(
-    key: string,
-    field_or_record: string | Record<string, string>,
-    value?: string,
-  ) {
+  // deno-lint-ignore no-explicit-any
+  hset(key: string, ...params: any[]) {
     const args = [key];
-    if (typeof field_or_record === "string" && value !== undefined) {
-      args.push(field_or_record, value);
-    } else {
-      for (let [field, value] of Object.entries(field_or_record)) {
-        args.push(field, value);
+    if (Array.isArray(params[0])) {
+      args.push(...params.flatMap((e) => e));
+    } else if (typeof params[0] === "object") {
+      for (let [field, value] of Object.entries(params[0])) {
+        args.push(field, value as string);
       }
-    }
+    } else {
+      args.push(...params);
+      }
     return this.execIntegerReply("HSET", ...args);
   }
 
@@ -883,27 +875,33 @@ export class RedisImpl implements Redis {
     return this.execIntegerReply("MOVE", key, db);
   }
 
-  mset(key_or_record: string | Record<string, string>, value?: string) {
+  // deno-lint-ignore no-explicit-any
+  mset(...params: any[]) {
     const args: string[] = [];
-    if (typeof key_or_record === "string" && value !== undefined) {
-      args.push(key_or_record, value);
-    } else {
-      for (let [key, value] of Object.entries(key_or_record)) {
-        args.push(key, value);
+    if (Array.isArray(params[0])) {
+      args.push(...params.flatMap((e) => e));
+    } else if (typeof params[0] === "object") {
+      for (let [key, value] of Object.entries(params[0])) {
+        args.push(key, value as string);
       }
-    }
+    } else {
+      args.push(...params);
+      }
     return this.execStatusReply("MSET", ...args);
   }
 
-  msetnx(key_or_record: string | Record<string, string>, value?: string) {
+  // deno-lint-ignore no-explicit-any
+  msetnx(...params: any[]) {
     const args: string[] = [];
-    if (typeof key_or_record === "string" && value !== undefined) {
-      args.push(key_or_record, value);
-    } else {
-      for (let [key, value] of Object.entries(key_or_record)) {
-        args.push(key, value);
+    if (Array.isArray(params[0])) {
+      args.push(...params.flatMap((e) => e));
+    } else if (typeof params[0] === "object") {
+      for (let [key, value] of Object.entries(params[0])) {
+        args.push(key, value as string);
       }
-    }
+    } else {
+      args.push(...params);
+      }
     return this.execIntegerReply("MSETNX", ...args);
   }
 
@@ -1190,7 +1188,7 @@ export class RedisImpl implements Redis {
     return this.execStatusReply("SLAVEOF", host, port);
   }
 
-  slaveof_none() {
+  slaveof_no_one() {
     return this.execStatusReply("SLAVEOF", "NO ONE");
   }
 
@@ -1198,7 +1196,7 @@ export class RedisImpl implements Redis {
     return this.execStatusReply("REPLICAOF", host, port);
   }
 
-  replicaof_none() {
+  replicaof_no_one() {
     return this.execStatusReply("REPLICAOF", "NO ONE");
   }
 
@@ -1771,26 +1769,19 @@ export class RedisImpl implements Redis {
     return this.execIntegerReply("XTRIM", key, "MAXLEN", ...args);
   }
 
-  zadd(
-    key: string,
-    score_or_record: number | Record<string, number>,
-    member_or_opts?: string | { mode?: "NX" | "XX"; ch?: boolean },
-    opts?: { mode?: "NX" | "XX"; ch?: boolean },
-  ) {
+  // deno-lint-ignore no-explicit-any
+  zadd(key: string, param1: any, param2?: any, opts?: any) {
     const args: (string | number)[] = [key];
-    if (
-      typeof score_or_record === "number" &&
-      typeof member_or_opts === "string"
-    ) {
-      args.push(score_or_record);
-      args.push(member_or_opts);
+    if (Array.isArray(param1)) {
+      args.push(...param1.flatMap((e) => e));
+      opts = param2;
+    } else if (typeof param1 === "object") {
+      for (let [member, score] of Object.entries(param1)) {
+        args.push(score as number, member);
+      }
+      opts = param2;
     } else {
-      for (let [member, score] of Object.entries(score_or_record)) {
-        args.push(score, member);
-      }
-      if (typeof member_or_opts === "object") {
-        opts = member_or_opts;
-      }
+      args.push(param1, param2);
     }
     if (opts?.mode) {
       args.push(opts.mode);
@@ -1832,34 +1823,42 @@ export class RedisImpl implements Redis {
 
   zinterstore(
     destination: string,
-    keys_or_record: string[] | Record<string, number>,
+    keys: string[] | [string, number][] | Record<string, number>,
     opts?: { aggregate?: "SUM" | "MIN" | "MAX" },
   ) {
-    const args = this.pushZStoreArgs([destination], keys_or_record, opts);
+    const args = this.pushZStoreArgs([destination], keys, opts);
     return this.execIntegerReply("ZINTERSTORE", ...args);
   }
 
   zunionstore(
     destination: string,
-    keys_or_record: string[] | Record<string, number>,
+    keys: string[] | [string, number][] | Record<string, number>,
     opts?: { aggregate?: "SUM" | "MIN" | "MAX" },
   ) {
-    const args = this.pushZStoreArgs([destination], keys_or_record, opts);
+    const args = this.pushZStoreArgs([destination], keys, opts);
     return this.execIntegerReply("ZUNIONSTORE", ...args);
   }
 
   private pushZStoreArgs(
     args: (number | string)[],
-    keys_or_record: string[] | Record<string, number>,
+    keys: string[] | [string, number][] | Record<string, number>,
     opts?: { aggregate?: "SUM" | "MIN" | "MAX" },
   ) {
-    if (Array.isArray(keys_or_record)) {
-      args.push(keys_or_record.length, ...keys_or_record);
+    if (Array.isArray(keys)) {
+      args.push(keys.length);
+      if (Array.isArray(keys[0])) {
+        keys = keys as [string, number][];
+        args.push(...keys.map((e) => e[0]));
+        args.push("WEIGHTS");
+        args.push(...keys.map((e) => e[1]));
+      } else {
+        args.push(...(keys as string[]));
+      }
     } else {
-      args.push(Object.keys(keys_or_record).length);
-      args.push(...Object.keys(keys_or_record));
+      args.push(Object.keys(keys).length);
+      args.push(...Object.keys(keys));
       args.push("WEIGHTS");
-      args.push(...Object.values(keys_or_record));
+      args.push(...Object.values(keys));
     }
     if (opts?.aggregate) {
       args.push("AGGREGATE", opts.aggregate);

--- a/redis.ts
+++ b/redis.ts
@@ -524,7 +524,7 @@ export class RedisImpl implements Redis {
       }
     } else {
       args.push(...params);
-      }
+    }
     return this.execIntegerReply("GEOADD", ...args);
   }
 
@@ -696,7 +696,7 @@ export class RedisImpl implements Redis {
       }
     } else {
       args.push(...params);
-      }
+    }
     return this.execStatusReply("HMSET", ...args);
   }
 
@@ -711,7 +711,7 @@ export class RedisImpl implements Redis {
       }
     } else {
       args.push(...params);
-      }
+    }
     return this.execIntegerReply("HSET", ...args);
   }
 
@@ -886,7 +886,7 @@ export class RedisImpl implements Redis {
       }
     } else {
       args.push(...params);
-      }
+    }
     return this.execStatusReply("MSET", ...args);
   }
 
@@ -901,7 +901,7 @@ export class RedisImpl implements Redis {
       }
     } else {
       args.push(...params);
-      }
+    }
     return this.execIntegerReply("MSETNX", ...args);
   }
 

--- a/tests/general_test.ts
+++ b/tests/general_test.ts
@@ -99,7 +99,6 @@ suite.test("execRawReply", async () => {
 suite.test("eval", async () => {
   const raw = await client.eval(
     "return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}",
-    2,
     ["1", "2"],
     ["3", "4"],
   );

--- a/tests/geo_test.ts
+++ b/tests/geo_test.ts
@@ -20,31 +20,28 @@ suite.test("geoadd", async () => {
     1,
   );
   assertEquals(
-    await client.geoadd(
-      "Sicily",
-      [13.361389, 38.115556, "Palermo"],
-      [15.087269, 37.502669, "Catania"],
-    ),
+    await client.geoadd("Sicily", {
+      Palermo: [13.361389, 38.115556],
+      Catania: [15.087269, 37.502669],
+    }),
     0,
   );
 });
 
 suite.test("geohash", async () => {
-  await client.geoadd(
-    "Sicily",
-    [13.361389, 38.115556, "Palermo"],
-    [15.087269, 37.502669, "Catania"],
-  );
+  await client.geoadd("Sicily", {
+    Palermo: [13.361389, 38.115556],
+    Catania: [15.087269, 37.502669],
+  });
   const resp = await client.geohash("Sicily", "Palermo", "Catania", "Enna");
   assertEquals(resp, ["sqc8b49rny0", "sqdtr74hyu0", undefined]);
 });
 
 suite.test("geopos", async () => {
-  await client.geoadd(
-    "Sicily",
-    [13.361389, 38.115556, "Palermo"],
-    [15.087269, 37.502669, "Catania"],
-  );
+  await client.geoadd("Sicily", {
+    Palermo: [13.361389, 38.115556],
+    Catania: [15.087269, 37.502669],
+  });
   const resp = await client.geopos("Sicily", "Palermo", "Catania", "Enna");
   assertEquals(resp, [
     ["13.36138933897018433", "38.11555639549629859"],
@@ -54,11 +51,10 @@ suite.test("geopos", async () => {
 });
 
 suite.test("geodist", async () => {
-  await client.geoadd(
-    "Sicily",
-    [13.361389, 38.115556, "Palermo"],
-    [15.087269, 37.502669, "Catania"],
-  );
+  await client.geoadd("Sicily", {
+    Palermo: [13.361389, 38.115556],
+    Catania: [15.087269, 37.502669],
+  });
   let resp = await client.geodist("Sicily", "Palermo", "Catania");
   assertEquals(resp, "166274.1516");
   resp = await client.geodist("Sicily", "Palermo", "Enna");

--- a/tests/geo_test.ts
+++ b/tests/geo_test.ts
@@ -26,6 +26,14 @@ suite.test("geoadd", async () => {
     }),
     0,
   );
+  assertEquals(
+    await client.geoadd(
+      "Sicily",
+      [13.361389, 38.115556, "Palermo"],
+      [15.087269, 37.502669, "Catania"],
+    ),
+    0,
+  );
 });
 
 suite.test("geohash", async () => {

--- a/tests/hash_test.ts
+++ b/tests/hash_test.ts
@@ -73,11 +73,13 @@ suite.test("hmget", async () => {
 suite.test("hmset", async () => {
   assertEquals(await client.hmset("key", "f1", "1"), "OK");
   assertEquals(await client.hmset("key", { f1: "1", f2: "2" }), "OK");
+  assertEquals(await client.hmset("key", ["f4", "4"], ["f5", "5"]), "OK");
 });
 
 suite.test("hset", async () => {
   assertEquals(await client.hset("key", "f1", "1"), 1);
   assertEquals(await client.hset("key", { f2: "2", f3: "3" }), 2);
+  assertEquals(await client.hset("key", ["f4", "4"], ["f5", "5"]), 2);
 });
 
 suite.test("hsetnx", async () => {

--- a/tests/hash_test.ts
+++ b/tests/hash_test.ts
@@ -72,12 +72,12 @@ suite.test("hmget", async () => {
 
 suite.test("hmset", async () => {
   assertEquals(await client.hmset("key", "f1", "1"), "OK");
-  assertEquals(await client.hmset("key", "f1", "1", "f2", "2"), "OK");
+  assertEquals(await client.hmset("key", { f1: "1", f2: "2" }), "OK");
 });
 
 suite.test("hset", async () => {
   assertEquals(await client.hset("key", "f1", "1"), 1);
-  assertEquals(await client.hset("key", "f2", "2", "f3", "3"), 2);
+  assertEquals(await client.hset("key", { f2: "2", f3: "3" }), 2);
 });
 
 suite.test("hsetnx", async () => {

--- a/tests/key_test.ts
+++ b/tests/key_test.ts
@@ -87,7 +87,7 @@ suite.test("object encoding", async () => {
 
 suite.test("object idletime", async () => {
   await client.set("key", "baz");
-  const v = await client.object_ideltime("key");
+  const v = await client.object_idletime("key");
   assertEquals(v, 0);
 });
 

--- a/tests/list_test.ts
+++ b/tests/list_test.ts
@@ -16,20 +16,20 @@ suite.afterAll(() => {
 
 suite.test("blpoop", async () => {
   await client.rpush("list", "1", "2");
-  assertEquals(await client.blpop("list", 2), ["list", "1"]);
+  assertEquals(await client.blpop(2, "list"), ["list", "1"]);
 });
 
 suite.test("blpoop timeout", async () => {
-  assertEquals(await client.blpop("list", 1), []);
+  assertEquals(await client.blpop(1, "list"), []);
 });
 
 suite.test("brpoop", async () => {
   await client.rpush("list", "1", "2");
-  assertEquals(await client.brpop("list", 2), ["list", "2"]);
+  assertEquals(await client.brpop(2, "list"), ["list", "2"]);
 });
 
 suite.test("brpoop timeout", async () => {
-  assertEquals(await client.brpop("list", 1), []);
+  assertEquals(await client.brpop(1, "list"), []);
 });
 
 suite.test("brpoplpush", async () => {

--- a/tests/pipeline_test.ts
+++ b/tests/pipeline_test.ts
@@ -122,7 +122,7 @@ suite.test("error while pipeline", async () => {
   const client = await newClient(opts);
   const tx = client.pipeline();
   tx.set("a", "a");
-  tx.eval("var", 1, "k", "v");
+  tx.eval("var", ["k"], ["v"]);
   tx.get("a");
   const resp = await tx.flush();
   assertEquals(resp.length, 3);

--- a/tests/sorted_set_test.ts
+++ b/tests/sorted_set_test.ts
@@ -18,208 +18,131 @@ suite.afterAll(() => {
 });
 
 suite.test("bzpopmin", async () => {
-  await client.zadd("key", [
-    [1, "1"],
-    [2, "2"],
-  ]);
-  assertEquals(await client.bzpopmin("key", 1), ["key", "1", "1"]);
+  await client.zadd("key", { "1": 1, "2": 2 });
+  assertEquals(await client.bzpopmin(1, "key"), ["key", "1", "1"]);
 });
 
 suite.test("bzpopmin timeout", async () => {
-  const arr = await client.bzpopmin("key", 1);
+  const arr = await client.bzpopmin(1, "key");
   assertEquals(arr.length, 0);
 });
 
 suite.test("bzpopmax", async () => {
-  await client.zadd("key", [
-    [1, "1"],
-    [2, "2"],
-  ]);
-  assertEquals(await client.bzpopmax("key", 1), ["key", "2", "2"]);
+  await client.zadd("key", { "1": 1, "2": 2 });
+  assertEquals(await client.bzpopmax(1, "key"), ["key", "2", "2"]);
 });
 
 suite.test("bzpopmax timeout", async () => {
-  const arr = await client.bzpopmax("key", 1);
+  const arr = await client.bzpopmax(1, "key");
   assertEquals(arr.length, 0);
 });
 
 suite.test("zadd", async () => {
-  assertEquals(
-    await client.zadd("key", [
-      [1, "1"],
-      [2, "2"],
-    ]),
-    2,
-  );
+  assertEquals(await client.zadd("key", { "1": 1, "2": 2 }), 2);
+  assertEquals(await client.zadd("key", 3, "3"), 1);
 });
 
 suite.test("zcount", async () => {
-  await client.zadd("key", [
-    [1, "1"],
-    [2, "2"],
-  ]);
+  await client.zadd("key", { "1": 1, "2": 2 });
   assertEquals(await client.zcount("key", 0, 1), 1);
 });
 
 suite.test("zincrby", async () => {
-  await client.zadd("key", [
-    [1, "1"],
-    [2, "2"],
-  ]);
+  await client.zadd("key", { "1": 1, "2": 2 });
   const v = await client.zincrby("key", 2.0, "1");
   assert(v != null);
   assert(parseFloat(v) - 3.0 < Number.EPSILON);
 });
 
 suite.test("zinterstore", async () => {
-  await client.zadd("key", [
-    [1, "1"],
-    [2, "2"],
-  ]);
-  await client.zadd("key2", [
-    [1, "1"],
-    [3, "3"],
-  ]);
-  assertEquals(await client.zinterstore("dest", 2, ["key", "key2"]), 1);
+  await client.zadd("key", { "1": 1, "2": 2 });
+  await client.zadd("key2", { "1": 1, "3": 3 });
+  assertEquals(await client.zinterstore("dest", ["key", "key2"]), 1);
 });
 
 suite.test("zlexcount", async () => {
-  await client.zadd("key2", [
-    [1, "1"],
-    [2, "2"],
-  ]);
+  await client.zadd("key2", { "1": 1, "2": 2 });
   assertEquals(await client.zlexcount("key", "-", "(2"), 0);
 });
 
 suite.test("zpopmax", async () => {
-  await client.zadd("key", [
-    [1, "one"],
-    [2, "two"],
-  ]);
+  await client.zadd("key", { one: 1, two: 2 });
   assertEquals(await client.zpopmax("key", 1), ["two", "2"]);
 });
 
 suite.test("zrange", async () => {
-  await client.zadd("key", [
-    [1, "one"],
-    [2, "two"],
-  ]);
+  await client.zadd("key", { one: 1, two: 2 });
   assertEquals(await client.zrange("key", 1, 2), ["two"]);
 });
 
 suite.test("zrangebylex", async () => {
-  await client.zadd("key", [
-    [1, "one"],
-    [2, "two"],
-  ]);
+  await client.zadd("key", { one: 1, two: 2 });
   assertEquals(await client.zrangebylex("key", "-", "(2"), []);
 });
 
 suite.test("zrevrangebylex", async () => {
-  await client.zadd("key", [
-    [1, "one"],
-    [2, "two"],
-  ]);
+  await client.zadd("key", { one: 1, two: 2 });
   assertEquals(await client.zrevrangebylex("key", "(2", "-"), []);
 });
 
 suite.test("zrangebyscore", async () => {
-  await client.zadd("key", [
-    [1, "one"],
-    [2, "two"],
-  ]);
+  await client.zadd("key", { one: 1, two: 2 });
   assertEquals(await client.zrangebyscore("key", "1", "2"), ["one", "two"]);
 });
 
 suite.test("zrank", async () => {
-  await client.zadd("key", [
-    [1, "one"],
-    [2, "two"],
-  ]);
+  await client.zadd("key", { one: 1, two: 2 });
   assertEquals(await client.zrank("key", "two"), 1);
 });
 
 suite.test("zrem", async () => {
-  client.zadd("key", [
-    [1, "one"],
-    [2, "two"],
-  ]);
+  client.zadd("key", { one: 1, two: 2 });
   assertEquals(await client.zrem("key", "one"), 1);
 });
 
 suite.test("zremrangebylex", async () => {
-  client.zadd("key", [
-    [1, "one"],
-    [2, "two"],
-  ]);
+  client.zadd("key", { one: 1, two: 2 });
   assertEquals(await client.zremrangebylex("key", "[one", "[two"), 2);
 });
 
 suite.test("zremrangebyrank", async () => {
-  client.zadd("key", [
-    [1, "one"],
-    [2, "two"],
-  ]);
+  client.zadd("key", { one: 1, two: 2 });
   assertEquals(await client.zremrangebyrank("key", 1, 2), 1);
 });
 
 suite.test("zremrangebyscore", async () => {
-  client.zadd("key", [
-    [1, "one"],
-    [2, "two"],
-  ]);
+  client.zadd("key", { one: 1, two: 2 });
   assertEquals(await client.zremrangebyscore("key", 1, 2), 2);
 });
 
 suite.test("zrevrange", async () => {
-  client.zadd("key", [
-    [1, "one"],
-    [2, "two"],
-  ]);
+  client.zadd("key", { one: 1, two: 2 });
   assertEquals(await client.zrevrange("key", 1, 2), ["one"]);
 });
 
 suite.test("zrevrangebyscore", async () => {
-  client.zadd("key", [
-    [1, "one"],
-    [2, "two"],
-  ]);
+  client.zadd("key", { one: 1, two: 2 });
   assertEquals(await client.zrevrangebyscore("key", 2, 1), ["two", "one"]);
 });
 
 suite.test("zrevrank", async () => {
-  client.zadd("key", [
-    [1, "one"],
-    [2, "two"],
-  ]);
+  client.zadd("key", { one: 1, two: 2 });
   assertEquals(await client.zrevrank("key", "one"), 1);
 });
 
 suite.test("zscore", async () => {
-  client.zadd("key", [
-    [1, "one"],
-    [2, "two"],
-  ]);
+  client.zadd("key", { one: 1, two: 2 });
   assertEquals(await client.zscore("key", "one"), "1");
 });
 
 suite.test("zunionstore", async () => {
-  client.zadd("key", [
-    [1, "one"],
-    [2, "two"],
-  ]);
-  client.zadd("key2", [
-    [1, "one"],
-    [3, "three"],
-  ]);
+  client.zadd("key", { one: 1, two: 2 });
+  client.zadd("key2", { one: 1, three: 3 });
   assertEquals(await client.zunionstore("dest", ["key", "key2"]), 3);
 });
 
 suite.test("zscan", async () => {
-  client.zadd("key", [
-    [1, "one"],
-    [2, "two"],
-  ]);
+  client.zadd("key", { one: 1, two: 2 });
   assertEquals(await client.zscan("key", 1), ["0", ["one", "1", "two", "2"]]);
 });
 
@@ -235,7 +158,7 @@ suite.test("testZrangeWithScores", async function testZrangeWithScores() {
   client.zadd("zrangeWithScores", 1, "one");
   client.zadd("zrangeWithScores", 2, "two");
   client.zadd("zrangeWithScores", 3, "three");
-  const v = await client.zrange("zrangeWithScores", 0, 1, { withScore: true });
+  const v = await client.zrange("zrangeWithScores", 0, 1, { with_score: true });
   assertEquals(v, ["one", "1", "two", "2"]);
 });
 
@@ -252,7 +175,7 @@ suite.test("testZrevrangeWithScores", async function testZrevrangeWithScores() {
   client.zadd("zrevrangeWithScores", 2, "two");
   client.zadd("zrevrangeWithScores", 3, "three");
   const v = await client.zrevrange("zrevrangeWithScores", 0, 1, {
-    withScore: true,
+    with_score: true,
   });
   assertEquals(v, ["three", "3", "two", "2"]);
 });
@@ -274,7 +197,7 @@ suite.test(
     client.zadd("zrangebyscoreWithScores", 8, "m3");
     client.zadd("zrangebyscoreWithScores", 10, "m4");
     const v = await client.zrangebyscore("zrangebyscoreWithScores", 3, 9, {
-      withScore: true,
+      with_score: true,
     });
     assertEquals(v, ["m2", "5", "m3", "8"]);
   },
@@ -295,7 +218,7 @@ suite.test("testZrevrangebyscore", async function testZrevrangebyscore() {
   client.zadd("zrevrangebyscoreWithScores", 8, "m3");
   client.zadd("zrevrangebyscoreWithScores", 10, "m4");
   const v = await client.zrevrangebyscore("zrevrangebyscoreWithScores", 9, 4, {
-    withScore: true,
+    with_score: true,
   });
   assertEquals(v, ["m3", "8", "m2", "5"]);
 });

--- a/tests/sorted_set_test.ts
+++ b/tests/sorted_set_test.ts
@@ -40,6 +40,13 @@ suite.test("bzpopmax timeout", async () => {
 suite.test("zadd", async () => {
   assertEquals(await client.zadd("key", { "1": 1, "2": 2 }), 2);
   assertEquals(await client.zadd("key", 3, "3"), 1);
+  assertEquals(
+    await client.zadd("key", [
+      [4, "4"],
+      [5, "5"],
+    ]),
+    2,
+  );
 });
 
 suite.test("zcount", async () => {

--- a/tests/string_test.ts
+++ b/tests/string_test.ts
@@ -133,6 +133,8 @@ suite.test("mset", async () => {
   assertEquals(rep, "OK");
   rep = await client.mset({ key2: "bar", key3: "baz" });
   assertEquals(rep, "OK");
+  rep = await client.mset(["key4", "bar"], ["key5", "baz"]);
+  assertEquals(rep, "OK");
   assertEquals(await client.get("key1"), "foo");
   assertEquals(await client.get("key2"), "bar");
   assertEquals(await client.get("key3"), "baz");
@@ -143,6 +145,8 @@ suite.test("msetnx", async () => {
   assertEquals(rep1, 1); // All the keys were set.
   rep1 = await client.msetnx({ key2: "bar" });
   assertEquals(rep1, 1); // All the keys were set.
+  rep1 = await client.msetnx(["key4", "bar"], ["key5", "baz"]);
+  assertEquals(rep1, 1);
   const rep2 = await client.msetnx({ key2: "baz", key3: "qux" });
   assertEquals(rep2, 0); // No key was set.
   assertEquals(await client.get("key1"), "foo");

--- a/tests/string_test.ts
+++ b/tests/string_test.ts
@@ -129,7 +129,9 @@ suite.test("mget", async () => {
 });
 
 suite.test("mset", async () => {
-  const rep = await client.mset("key1", "foo", "key2", "bar", "key3", "baz");
+  let rep = await client.mset("key1", "foo");
+  assertEquals(rep, "OK");
+  rep = await client.mset({ key2: "bar", key3: "baz" });
   assertEquals(rep, "OK");
   assertEquals(await client.get("key1"), "foo");
   assertEquals(await client.get("key2"), "bar");
@@ -137,9 +139,11 @@ suite.test("mset", async () => {
 });
 
 suite.test("msetnx", async () => {
-  const rep1 = await client.msetnx("key1", "foo", "key2", "bar");
+  let rep1 = await client.msetnx("key1", "foo");
   assertEquals(rep1, 1); // All the keys were set.
-  const rep2 = await client.msetnx("key2", "baz", "key3", "qux");
+  rep1 = await client.msetnx({ key2: "bar" });
+  assertEquals(rep1, 1); // All the keys were set.
+  const rep2 = await client.msetnx({ key2: "baz", key3: "qux" });
   assertEquals(rep2, 0); // No key was set.
   assertEquals(await client.get("key1"), "foo");
   assertEquals(await client.get("key2"), "bar");


### PR DESCRIPTION
This PR aims to improve the commands API to better conform with the actual Redis API and improve developer experience.

### Adjustment
-  `migrate`: add `auth` option
-  `object_idletime`: rename the function
-  `object_freq`: add `BulkNil` to return type
-  `restore`: add `absttl`, `idletime`, and `freq` options
-  `scan`: add `type` options
-  `sort`: make `limit` option an object and make `order` optional
-  `incrbyfloat`: return type `BulkString`
-  `mset`: use Record to add multiple entries
-  `msetnx`, `geoadd`, `hmset`, and `hset`: ditto
-  `set`: add `keepttl` option
-  `geopos`: return type `BulkString`
-  `geo*` : adjust options names
-  `bzop*`: make `timeout` first argument to use rest with `keys`
-  `z*store`: use Record to add multiple arguments
-  `eval`: remove `numkeys` argument, get this value from `keys.length`
-  `acl*` and `memory*`: adjust some commands to return `BulkString` instead of `Status`

### Addition
-  `zadd_incr`: `zadd` with `incr` option that only accepts a single member score pair and returns `Bulk`
-  `replicaof_none`: `REPLICAOF NO ONE`
-  `slaveof_none`: `SLAVEOF NO ONE`

---
- [x] Fix broken tests
- [x] Group commands into groups as in redis.io
- [x] Apply consistent formatting
