### PR TITLE
Fix #146 TS1371 must use 'import type' because the 'importsNotUsedAsV…

### DIFF
--- a/command.ts
+++ b/command.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Bulk,
   BulkNil,
   BulkString,
@@ -7,9 +7,9 @@ import {
   Raw,
   Status,
 } from "./io.ts";
-import { RedisPipeline } from "./pipeline.ts";
-import { RedisSubscription } from "./pubsub.ts";
-import {
+import type { RedisPipeline } from "./pipeline.ts";
+import type { RedisSubscription } from "./pubsub.ts";
+import type {
   StartEndCount,
   XAddFieldValues,
   XClaimOpts,

--- a/executor.ts
+++ b/executor.ts
@@ -1,4 +1,4 @@
-import { Connection } from "./connection.ts";
+import type { Connection } from "./connection.ts";
 import { EOFError } from "./errors.ts";
 import { RedisRawReply, sendCommand } from "./io.ts";
 import { Deferred, deferred } from "./vendor/https/deno.land/std/async/mod.ts";

--- a/io.ts
+++ b/io.ts
@@ -1,5 +1,8 @@
 import { EOFError, ErrorReplyError, InvalidStateError } from "./errors.ts";
-import { BufReader, BufWriter } from "./vendor/https/deno.land/std/io/bufio.ts";
+import type {
+  BufReader,
+  BufWriter,
+} from "./vendor/https/deno.land/std/io/bufio.ts";
 
 export type Status = string;
 export type Integer = number;

--- a/pipeline.ts
+++ b/pipeline.ts
@@ -1,4 +1,4 @@
-import { Connection } from "./connection.ts";
+import type { Connection } from "./connection.ts";
 import { CommandExecutor } from "./executor.ts";
 import { RawReplyOrError, RedisRawReply, sendCommands } from "./io.ts";
 import { Redis, RedisImpl } from "./redis.ts";

--- a/pubsub.ts
+++ b/pubsub.ts
@@ -1,4 +1,4 @@
-import { Connection } from "./connection.ts";
+import type { Connection } from "./connection.ts";
 import { InvalidStateError } from "./errors.ts";
 import { readArrayReply, sendCommand } from "./io.ts";
 

--- a/redis.ts
+++ b/redis.ts
@@ -1,7 +1,7 @@
-import { RedisCommands } from "./command.ts";
+import type { RedisCommands } from "./command.ts";
 import { Connection, RedisConnection } from "./connection.ts";
 import { CommandExecutor, MuxExecutor } from "./executor.ts";
-import {
+import type {
   Bulk,
   BulkNil,
   BulkString,

--- a/stream.ts
+++ b/stream.ts
@@ -1,4 +1,4 @@
-import { ConditionalArray, Raw } from "./io.ts";
+import type { ConditionalArray, Raw } from "./io.ts";
 
 export interface XId {
   unixMs: number;


### PR DESCRIPTION
…alues' is set to 'error'