### PR TITLE
ci: use GITHUB_ENV instead of set-env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Get Deno version
         run: |
-          echo "::set-env name=DENO_VERSION::$(cat .denov)"
+          echo "DENO_VERSION=$(cat .denov)" >> $GITHUB_ENV
 
       - name: Set up Deno ${{ env.DENO_VERSION }}
         uses: denolib/setup-deno@master


### PR DESCRIPTION
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/