### PR TITLE
resolve #153 - add parseURL function

### DIFF
--- a/redis.ts
+++ b/redis.ts
@@ -2112,7 +2112,8 @@ export async function connect(options: RedisConnectOptions): Promise<Redis> {
  * Extract RedisConnectOptions from redis URL
  * @param url
  * @example
- *  const options = parseURL("redis://foo:bar@localhost:6379/1") // -> {hostname: "localhost", port: "6379", tls: false, db: 1, name: foo, password: bar}
+ *  `const options = parseURL("redis://foo:bar@localhost:6379/1")` // -> {hostname: "localhost", port: "6379", tls: false, db: 1, name: foo, password: bar}
+ *  `const options = parseURL("rediss://127.0.0.1:443/?db=2&password=bar")` // -> {hostname: "127.0.0.1", port: "443", tls: true, db: 2, name: undefined, password: bar}
  */
 export function parseURL(url: string): RedisConnectOptions {
   const {

--- a/redis.ts
+++ b/redis.ts
@@ -2107,3 +2107,34 @@ export async function connect(options: RedisConnectOptions): Promise<Redis> {
   const executor = new MuxExecutor(connection);
   return new RedisImpl(connection, executor);
 }
+
+/**
+ * Extract RedisConnectOptions from redis URL
+ * @param url
+ * @example
+ *  const options = parseURL("redis://foo:bar@localhost:6379/1") // -> {hostname: "localhost", port: "6379", tls: false, db: 1, name: foo, password: bar}
+ */
+export function parseURL(url: string): RedisConnectOptions {
+  const {
+    protocol,
+    hostname,
+    port,
+    username,
+    password,
+    pathname,
+    searchParams,
+  } = new URL(url);
+  const db = pathname.replace("/", "") !== ""
+    ? pathname.replace("/", "")
+    : searchParams.get("db") ?? undefined;
+  return {
+    hostname: hostname !== "" ? hostname : "localhost",
+    port: port !== "" ? parseInt(port, 10) : 6379,
+    tls: protocol == "rediss:" ? true : searchParams.get("ssl") === "true",
+    db: db ? parseInt(db, 10) : undefined,
+    name: username !== "" ? username : undefined,
+    password: password !== ""
+      ? password
+      : searchParams.get("password") ?? undefined,
+  };
+}

--- a/tests/connection_test.ts
+++ b/tests/connection_test.ts
@@ -1,4 +1,4 @@
-import { connect, parseURL } from "../redis.ts";
+import { connect } from "../redis.ts";
 import { assertEquals } from "../vendor/https/deno.land/std/testing/asserts.ts";
 import { newClient, startRedis, stopRedis, TestSuite } from "./test_util.ts";
 
@@ -35,60 +35,6 @@ suite.test("select", async () => {
 
 suite.test("swapdb", async () => {
   assertEquals(await client.swapdb(0, 1), "OK");
-});
-
-suite.test("parse basic URL", () => {
-  const options = parseURL("redis://127.0.0.1:7003");
-  assertEquals(options.hostname, "127.0.0.1");
-  assertEquals(options.port, 7003);
-  assertEquals(options.tls, false);
-  assertEquals(options.db, undefined);
-  assertEquals(options.name, undefined);
-  assertEquals(options.password, undefined);
-});
-
-suite.test("parse complex URL", () => {
-  const options = parseURL("rediss://username:password@127.0.0.1:7003/1");
-  assertEquals(options.hostname, "127.0.0.1");
-  assertEquals(options.port, 7003);
-  assertEquals(options.tls, true);
-  assertEquals(options.db, 1);
-  assertEquals(options.name, "username");
-  assertEquals(options.password, "password");
-});
-
-suite.test("parse URL with search options", () => {
-  const options = parseURL(
-    "redis://127.0.0.1:7003/?db=2&password=password&ssl=true",
-  );
-  assertEquals(options.hostname, "127.0.0.1");
-  assertEquals(options.port, 7003);
-  assertEquals(options.tls, true);
-  assertEquals(options.db, 2);
-  assertEquals(options.name, undefined);
-  assertEquals(options.password, "password");
-});
-
-suite.test("Check parameter parsing priority", () => {
-  const options = parseURL(
-    "rediss://username:password@127.0.0.1:7003/1?db=2&password=password2&ssl=false",
-  );
-  assertEquals(options.hostname, "127.0.0.1");
-  assertEquals(options.port, 7003);
-  assertEquals(options.tls, true);
-  assertEquals(options.db, 1);
-  assertEquals(options.name, "username");
-  assertEquals(options.password, "password");
-});
-
-suite.test("connect with URL", async () => {
-  const options = parseURL("redis://127.0.0.1:7003/1");
-  const tempClient = await connect(options);
-  assertEquals(tempClient.isConnected, true);
-  assertEquals(tempClient.isClosed, false);
-  assertEquals(await tempClient.quit(), "OK");
-  assertEquals(tempClient.isConnected, false);
-  assertEquals(tempClient.isClosed, true);
 });
 
 suite.runTests();

--- a/tests/connection_test.ts
+++ b/tests/connection_test.ts
@@ -1,4 +1,4 @@
-import { connect } from "../redis.ts";
+import { connect, parseURL } from "../redis.ts";
 import { assertEquals } from "../vendor/https/deno.land/std/testing/asserts.ts";
 import { newClient, startRedis, stopRedis, TestSuite } from "./test_util.ts";
 
@@ -35,6 +35,50 @@ suite.test("select", async () => {
 
 suite.test("swapdb", async () => {
   assertEquals(await client.swapdb(0, 1), "OK");
+});
+
+suite.test("parse basic URL", () => {
+  const options = parseURL("redis://127.0.0.1:7003");
+  assertEquals(options.hostname, "127.0.0.1");
+  assertEquals(options.port, 7003);
+  assertEquals(options.tls, false);
+  assertEquals(options.db, undefined);
+  assertEquals(options.name, undefined);
+  assertEquals(options.password, undefined);
+});
+
+suite.test("parse complex URL", () => {
+  const options = parseURL("rediss://username:password@127.0.0.1:7003/1");
+  assertEquals(options.hostname, "127.0.0.1");
+  assertEquals(options.port, 7003);
+  assertEquals(options.tls, true);
+  assertEquals(options.db, 1);
+  assertEquals(options.name, "username");
+  assertEquals(options.password, "password");
+});
+
+suite.test("parse URL with search options", () => {
+  const options = parseURL(
+    "redis://127.0.0.1:7003/?db=2&password=password&ssl=true",
+  );
+  assertEquals(options.hostname, "127.0.0.1");
+  assertEquals(options.port, 7003);
+  assertEquals(options.tls, true);
+  assertEquals(options.db, 2);
+  assertEquals(options.name, undefined);
+  assertEquals(options.password, "password");
+});
+
+suite.test("Check parameter parsing priority", () => {
+  const options = parseURL(
+    "rediss://username:password@127.0.0.1:7003/1?db=2&password=password2&ssl=false",
+  );
+  assertEquals(options.hostname, "127.0.0.1");
+  assertEquals(options.port, 7003);
+  assertEquals(options.tls, true);
+  assertEquals(options.db, 1);
+  assertEquals(options.name, "username");
+  assertEquals(options.password, "password");
 });
 
 suite.runTests();

--- a/tests/connection_test.ts
+++ b/tests/connection_test.ts
@@ -81,4 +81,14 @@ suite.test("Check parameter parsing priority", () => {
   assertEquals(options.password, "password");
 });
 
+suite.test("connect with URL", async () => {
+  const options = parseURL("redis://127.0.0.1:7003/1");
+  const tempClient = await connect(options);
+  assertEquals(tempClient.isConnected, true);
+  assertEquals(tempClient.isClosed, false);
+  assertEquals(await tempClient.quit(), "OK");
+  assertEquals(tempClient.isConnected, false);
+  assertEquals(tempClient.isClosed, true);
+});
+
 suite.runTests();

--- a/tests/general_test.ts
+++ b/tests/general_test.ts
@@ -1,3 +1,4 @@
+import { parseURL } from "../redis.ts";
 import { ErrorReplyError } from "../errors.ts";
 import {
   assert,
@@ -104,6 +105,50 @@ suite.test("eval", async () => {
   );
   assert(Array.isArray(raw));
   assertEquals(raw, ["1", "2", "3", "4"]);
+});
+
+suite.test("parse basic URL", () => {
+  const options = parseURL("redis://127.0.0.1:7003");
+  assertEquals(options.hostname, "127.0.0.1");
+  assertEquals(options.port, 7003);
+  assertEquals(options.tls, false);
+  assertEquals(options.db, undefined);
+  assertEquals(options.name, undefined);
+  assertEquals(options.password, undefined);
+});
+
+suite.test("parse complex URL", () => {
+  const options = parseURL("rediss://username:password@127.0.0.1:7003/1");
+  assertEquals(options.hostname, "127.0.0.1");
+  assertEquals(options.port, 7003);
+  assertEquals(options.tls, true);
+  assertEquals(options.db, 1);
+  assertEquals(options.name, "username");
+  assertEquals(options.password, "password");
+});
+
+suite.test("parse URL with search options", () => {
+  const options = parseURL(
+    "redis://127.0.0.1:7003/?db=2&password=password&ssl=true",
+  );
+  assertEquals(options.hostname, "127.0.0.1");
+  assertEquals(options.port, 7003);
+  assertEquals(options.tls, true);
+  assertEquals(options.db, 2);
+  assertEquals(options.name, undefined);
+  assertEquals(options.password, "password");
+});
+
+suite.test("Check parameter parsing priority", () => {
+  const options = parseURL(
+    "rediss://username:password@127.0.0.1:7003/1?db=2&password=password2&ssl=false",
+  );
+  assertEquals(options.hostname, "127.0.0.1");
+  assertEquals(options.port, 7003);
+  assertEquals(options.tls, true);
+  assertEquals(options.db, 1);
+  assertEquals(options.name, "username");
+  assertEquals(options.password, "password");
 });
 
 suite.runTests();


### PR DESCRIPTION
Resolves #153 

This adds a helper function to `redis.ts` (I think it's the right place? I don't really see any file for helpers and `connection.ts` seems to be more focused on internal operation of connecting to redis). It takes a redis URL and parses it according to IANA assignments for [`redis`](https://www.iana.org/assignments/uri-schemes/prov/redis) and [`rediss`](https://www.iana.org/assignments/uri-schemes/prov/rediss) schemes.

Things I'm not certain of here:
- location of the function. As mentioned, I'm not sure if `redis.ts` is the right place for it
- tests and their location. I put them in `connection_test.ts`, but I don't know if they should stay there or go to `general_test.ts`. Also, originally I wanted there to be a test with a connection to server, but for some reason `connect` didn't want to work for me even with static values copied from a previous test that worked. Might be something with my environment though... EDIT: yes, it was something with my setup. No idea why, but it decided to start working. Added an actual connection test then.